### PR TITLE
fix(form): re-convert line item rates when token decimals change

### DIFF
--- a/src/widgets/invoice-form/ui/InvoiceItemRow.tsx
+++ b/src/widgets/invoice-form/ui/InvoiceItemRow.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import { Trash2Icon } from '@/shared/ui/icons'
 import { motion } from '@/shared/ui/motion'
 
@@ -46,6 +46,18 @@ export function InvoiceItemRow({
     }
     return ''
   })
+
+  // Sync rateInput display when decimals change (token switch).
+  // After PaymentSection re-converts atomic rates, this updates the displayed value.
+  const prevDecimalsRef = useRef(decimals)
+  useEffect(() => {
+    if (prevDecimalsRef.current !== decimals) {
+      prevDecimalsRef.current = decimals
+      if (item.rate && item.rate !== '0' && item.rate !== '') {
+        setRateInput(formatAmount(item.rate, decimals))
+      }
+    }
+  }, [decimals, item.rate])
 
   // Handle rate input change
   const handleRateChange = useCallback(

--- a/src/widgets/invoice-form/ui/sections/PaymentSection.tsx
+++ b/src/widgets/invoice-form/ui/sections/PaymentSection.tsx
@@ -11,6 +11,7 @@ import { Heading } from '@/shared/ui/typography'
 import { NetworkSelect } from '@/features/wallet-connect'
 import type { TokenInfo } from '@/entities/network'
 import { TokenSelect } from '@/features/invoice'
+import { formatAmount, parseAmount } from '@/shared/lib/amount-utils'
 
 import type { InvoiceFormValues } from '../../lib/use-invoice-form'
 
@@ -30,6 +31,31 @@ export function PaymentSection({ form }: PaymentSectionProps) {
   const decimals = watch('decimals')
 
   const setNetworkTheme = useCreatorStore((s) => s.setNetworkTheme)
+  const lineItems = useCreatorStore((s) => s.lineItems)
+  const updateLineItems = useCreatorStore((s) => s.updateLineItems)
+
+  // Re-convert line item rates when token decimals change.
+  // Rates are stored as atomic units tied to current decimals,
+  // so switching tokens requires conversion: old atomic → human → new atomic.
+  const reconvertLineItemRates = useCallback(
+    (oldDecimals: number, newDecimals: number) => {
+      if (oldDecimals === newDecimals) return
+      if (lineItems.length === 0) return
+
+      const hasNonZeroRate = lineItems.some((item) => item.rate && item.rate !== '0' && item.rate !== '')
+      if (!hasNonZeroRate) return
+
+      const reconverted = lineItems.map((item) => {
+        if (!item.rate || item.rate === '0' || item.rate === '') return item
+        const human = formatAmount(item.rate, oldDecimals, { useGrouping: false })
+        const newRate = parseAmount(human, newDecimals)
+        return { ...item, rate: newRate }
+      })
+
+      updateLineItems(reconverted)
+    },
+    [lineItems, updateLineItems]
+  )
 
   // Memoize token value to prevent unnecessary re-renders
   const tokenValue = useMemo(
@@ -46,14 +72,16 @@ export function PaymentSection({ form }: PaymentSectionProps) {
     [currency, tokenAddress, decimals]
   )
 
-  // Token change handler
+  // Token change handler — also re-converts line item rates if decimals differ
   const handleTokenChange = useCallback(
     (token: TokenInfo) => {
+      const oldDecimals = decimals || 18
+      reconvertLineItemRates(oldDecimals, token.decimals)
       setValue('currency', token.symbol)
       setValue('tokenAddress', token.address ?? undefined)
       setValue('decimals', token.decimals)
     },
-    [setValue]
+    [setValue, decimals, reconvertLineItemRates]
   )
 
   // Network change handler (also updates theme)

--- a/src/widgets/invoice-form/ui/sections/__tests__/PaymentSection.test.tsx
+++ b/src/widgets/invoice-form/ui/sections/__tests__/PaymentSection.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { findTokenForNetwork, NETWORK_TOKENS } from '@/entities/network'
+import { formatAmount, parseAmount } from '@/shared/lib/amount-utils'
 
 describe('PaymentSection network change logic', () => {
   it('findTokenForNetwork returns USDC for all supported networks', () => {
@@ -19,5 +20,89 @@ describe('PaymentSection network change logic', () => {
     const fallback = NETWORK_TOKENS[chainId]?.[0]
     expect(fallback).toBeDefined()
     expect(fallback!.symbol).toBe('ETH')
+  })
+})
+
+/**
+ * Re-convert a rate from old decimals to new decimals.
+ * Mirrors the logic in PaymentSection.reconvertLineItemRates.
+ */
+function reconvertRate(rate: string, oldDecimals: number, newDecimals: number): string {
+  if (!rate || rate === '0' || rate === '') return rate
+  const human = formatAmount(rate, oldDecimals, { useGrouping: false })
+  return parseAmount(human, newDecimals)
+}
+
+describe('Rate re-conversion on token decimals change', () => {
+  it('USDC (6 dec) → ETH (18 dec): preserves human-readable value', () => {
+    // $150.50 in USDC atomic units
+    const usdcRate = parseAmount('150.50', 6)
+    expect(usdcRate).toBe('150500000')
+
+    const ethRate = reconvertRate(usdcRate, 6, 18)
+    expect(ethRate).toBe('150500000000000000000')
+
+    // Verify human-readable roundtrip
+    expect(formatAmount(ethRate, 18, { useGrouping: false })).toBe('150.50')
+  })
+
+  it('ETH (18 dec) → USDC (6 dec): preserves human-readable value', () => {
+    const ethRate = parseAmount('0.05', 18)
+    expect(ethRate).toBe('50000000000000000')
+
+    const usdcRate = reconvertRate(ethRate, 18, 6)
+    expect(usdcRate).toBe('50000')
+
+    expect(formatAmount(usdcRate, 6, { useGrouping: false })).toBe('0.05')
+  })
+
+  it('same decimals (USDC → USDT both 6 dec): rate unchanged', () => {
+    const rate = parseAmount('100.00', 6)
+    const result = reconvertRate(rate, 6, 6)
+    expect(result).toBe(rate)
+  })
+
+  it('zero rate stays zero', () => {
+    expect(reconvertRate('0', 6, 18)).toBe('0')
+  })
+
+  it('empty rate stays empty', () => {
+    expect(reconvertRate('', 6, 18)).toBe('')
+  })
+
+  it('handles large amounts correctly', () => {
+    // $1,000,000.00 in USDC
+    const usdcRate = parseAmount('1000000', 6)
+    expect(usdcRate).toBe('1000000000000')
+
+    const ethRate = reconvertRate(usdcRate, 6, 18)
+    expect(formatAmount(ethRate, 18, { useGrouping: false })).toBe('1000000.00')
+  })
+
+  it('handles small fractional amounts', () => {
+    // $0.01 in USDC
+    const usdcRate = parseAmount('0.01', 6)
+    expect(usdcRate).toBe('10000')
+
+    const ethRate = reconvertRate(usdcRate, 6, 18)
+    expect(formatAmount(ethRate, 18, { useGrouping: false })).toBe('0.01')
+  })
+
+  it('handles multiple line items re-conversion', () => {
+    const items = [
+      { rate: parseAmount('150.50', 6) },
+      { rate: parseAmount('50.00', 6) },
+      { rate: '0' },
+      { rate: '' },
+    ]
+
+    const reconverted = items.map((item) => ({
+      rate: reconvertRate(item.rate, 6, 18),
+    }))
+
+    expect(formatAmount(reconverted[0].rate, 18, { useGrouping: false })).toBe('150.50')
+    expect(formatAmount(reconverted[1].rate, 18, { useGrouping: false })).toBe('50.00')
+    expect(reconverted[2].rate).toBe('0')
+    expect(reconverted[3].rate).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
- Fix: switching tokens (e.g. USDC→ETH) corrupted line item amounts because atomic unit rates were not re-converted for new decimal precision
- PaymentSection now reconverts all line item rates on token change via `formatAmount→parseAmount` roundtrip
- InvoiceItemRow syncs displayed price via `useEffect` when decimals prop changes

## Test plan
- [x] 8 new unit tests for rate re-conversion (USDC↔ETH, same decimals, zero/empty, large/small amounts, batch)
- [x] Type-check passes
- [x] Lint clean
- [x] All 106 existing invoice-form tests still pass