### PR TITLE
fix: invoice generation bugs — flash, source immutability, cross-tab sync

### DIFF
--- a/src/app/(app)/create/CreateWorkspace.tsx
+++ b/src/app/(app)/create/CreateWorkspace.tsx
@@ -44,7 +44,6 @@ export function CreateWorkspace() {
   const setNetworkTheme = useCreatorStore((s) => s.setNetworkTheme)
   const createNewDraft = useCreatorStore((s) => s.createNewDraft)
   const replaceDraft = useCreatorStore((s) => s.replaceDraft)
-  const clearDraft = useCreatorStore((s) => s.clearDraft)
   const draftSyncStatus = useCreatorStore((s) => s.draftSyncStatus)
 
   useEffect(() => {
@@ -175,10 +174,6 @@ export function CreateWorkspace() {
       invoiceUrl.pathname = invoiceUrl.pathname.replace('/pay', '/invoice')
       invoiceUrl.searchParams.set('share', '1')
       router.replace(urlToRoute(invoiceUrl))
-
-      // Defer draft clearing so the form stays in loading state during navigation
-      // (prevents visible flash of cleared form before route transition)
-      setTimeout(() => clearDraft(), 300)
       return
     } catch (error) {
       if (error instanceof UrlSizeError) {
@@ -193,7 +188,7 @@ export function CreateWorkspace() {
       }
       setIsGenerating(false)
     }
-  }, [isGenerating, clearDraft, router])
+  }, [isGenerating, router])
 
   return (
     <>

--- a/src/app/(app)/pay/CreatorHintBanner.tsx
+++ b/src/app/(app)/pay/CreatorHintBanner.tsx
@@ -58,7 +58,7 @@ export function CreatorHintBanner({ isCreator }: CreatorHintBannerProps) {
           </p>
           <button
             onClick={handleDismiss}
-            className="ml-3 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-zinc-700 hover:text-white"
+            className="ml-3 flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-zinc-700 hover:text-white"
             aria-label="Dismiss hint"
           >
             <XIcon size={14} />

--- a/src/entities/invoice/model/__tests__/rich-invoice-store.test.ts
+++ b/src/entities/invoice/model/__tests__/rich-invoice-store.test.ts
@@ -62,19 +62,19 @@ describe('useTrackedInvoiceStore', () => {
       expect(state.invoices[1].invoiceId).toBe('FIRST')
     })
 
-    it('merge-upserts existing invoice and moves to top', () => {
+    it('merge-upserts existing invoice and moves to top (source immutable)', () => {
       const { addInvoice } = useTrackedInvoiceStore.getState()
 
       addInvoice(createMockTrackedInvoice({ invoiceId: 'EXISTING', source: 'received' }))
       addInvoice(createMockTrackedInvoice({ invoiceId: 'OTHER' }))
 
-      // Re-add with overlaid fields
+      // Re-add with different source — original source preserved (first-write-wins)
       addInvoice(createMockTrackedInvoice({ invoiceId: 'EXISTING', source: 'created' }))
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(2)
       expect(state.invoices[0].invoiceId).toBe('EXISTING')
-      expect(state.invoices[0].source).toBe('created')
+      expect(state.invoices[0].source).toBe('received')
     })
 
     it('preserves existing createdAt on upsert', () => {
@@ -547,7 +547,7 @@ describe('useTrackedInvoiceStore', () => {
       expect(inv.error).toBe('some error')
     })
 
-    it('updates source on re-view', () => {
+    it('preserves original source on re-view (first-write-wins)', () => {
       const { addInvoice, trackView } = useTrackedInvoiceStore.getState()
 
       addInvoice(createMockTrackedInvoice({ invoiceId: 'SRC', source: 'created' }))
@@ -559,7 +559,7 @@ describe('useTrackedInvoiceStore', () => {
         viewedAt: '2026-03-10T16:00:00Z',
       })
 
-      expect(useTrackedInvoiceStore.getState().invoices[0].source).toBe('received')
+      expect(useTrackedInvoiceStore.getState().invoices[0].source).toBe('created')
     })
 
     it('moves viewed invoice to top of list (MRU order)', () => {
@@ -711,7 +711,7 @@ describe('useTrackedInvoiceStore', () => {
 
         const state = useTrackedInvoiceStore.getState()
         const inv = state.invoices.find((i) => i.invoiceId === 'MERGE-PRESERVE')!
-        expect(inv.source).toBe('received')
+        expect(inv.source).toBe('created') // source is immutable (first-write-wins)
         expect(inv.invoiceUrl).toBe('https://voidpay.xyz/pay#newurl')
         expect(inv.createdAt).toBe(originalCreatedAt)
       })

--- a/src/entities/invoice/model/rich-invoice-store.ts
+++ b/src/entities/invoice/model/rich-invoice-store.ts
@@ -62,6 +62,8 @@ function _upsertInvoice(
   const base = {
     ...existing,
     ...data,
+    // Preserve original source: 'created' must not be overwritten by 'received'
+    source: existing?.source ?? data.source,
     createdAt: existing?.createdAt ?? new Date().toISOString(),
   }
 
@@ -266,3 +268,12 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
     }
   )
 )
+
+// Cross-tab sync: rehydrate store when another tab updates localStorage
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (e.key === INVOICE_VIEW_STORE_KEY) {
+      void useTrackedInvoiceStore.persist.rehydrate()
+    }
+  })
+}


### PR DESCRIPTION
## Summary

- **Remove clearDraft setTimeout** that caused visible flash of empty invoice during navigation from /create to /invoice
- **Make TrackedInvoice.source immutable** (first-write-wins) so visiting /pay doesn't overwrite `created` → `received`, fixing history categorization and CreatorHintBanner detection
- **Add cross-tab localStorage sync** via `storage` event listener so /history tab picks up new invoices without page refresh
- **Add cursor-pointer** to CreatorHintBanner dismiss button

## Test plan

- [x] Generate invoice → no flash, smooth transition to /invoice page
- [x] Open /history in another tab — new invoice appears without refresh
- [x] Open /pay link for own invoice → source stays `created` in history
- [x] CreatorHintBanner dismiss button shows pointer cursor on hover
- [x] All 164 related tests pass (68 store + 96 pages)