### PR TITLE
fix(store): key TrackedInvoice by contentHash (SHA-256) instead of invoiceId

### DIFF
--- a/src/app/(app)/invoice/InvoiceVerifier.tsx
+++ b/src/app/(app)/invoice/InvoiceVerifier.tsx
@@ -6,7 +6,7 @@ import type { Invoice } from '@/shared/lib/invoice-types'
 
 interface InvoiceVerifierProps {
   invoice: Invoice
-  invoiceId: string
+  contentHash: string
   txHash: `0x${string}`
   exactTotal: string
   onReorgDetected?: (() => void) | undefined
@@ -15,7 +15,7 @@ interface InvoiceVerifierProps {
 function VerificationEffect(props: InvoiceVerifierProps) {
   usePaymentVerification(props)
   useFinalizationTracker({
-    invoiceId: props.invoiceId,
+    contentHash: props.contentHash,
     txHash: props.txHash,
     networkId: props.invoice.networkId,
     onReorgDetected: props.onReorgDetected,

--- a/src/app/(app)/invoice/InvoiceWorkspace.tsx
+++ b/src/app/(app)/invoice/InvoiceWorkspace.tsx
@@ -87,7 +87,7 @@ interface InvoiceWorkspaceReadyProps {
 function InvoiceWorkspaceReady({ invoice, view }: InvoiceWorkspaceReadyProps) {
   const {
     panelStatus, dismissError, txHash, confirmations, storedError,
-    finalized, exactTotal, polling, verifyTxHash, isSyncing,
+    finalized, exactTotal, polling, verifyTxHash, isSyncing, contentHash,
   } = view
 
   const searchParams = useSearchParams()
@@ -133,7 +133,7 @@ function InvoiceWorkspaceReady({ invoice, view }: InvoiceWorkspaceReadyProps) {
       {txHash && !finalized && (
         <InvoiceVerifier
           invoice={invoice}
-          invoiceId={invoice.invoiceId}
+          contentHash={contentHash}
           txHash={txHash}
           exactTotal={exactTotal}
           onReorgDetected={polling.startAutoCheck}

--- a/src/app/(app)/invoice/InvoiceWorkspace.tsx
+++ b/src/app/(app)/invoice/InvoiceWorkspace.tsx
@@ -179,6 +179,7 @@ function InvoiceWorkspaceReady({ invoice, view }: InvoiceWorkspaceReadyProps) {
                 {isPaid && txHash ? (
                   <PaymentPanel
                     invoice={invoice}
+                    contentHash={contentHash}
                     status={panelStatus}
                     txHash={txHash}
                     source="created"
@@ -190,6 +191,7 @@ function InvoiceWorkspaceReady({ invoice, view }: InvoiceWorkspaceReadyProps) {
                 ) : (
                   <PaymentPanel
                     invoice={invoice}
+                    contentHash={contentHash}
                     status={panelStatus}
                     source="created"
                     onShareOpen={() => handleShareOpenChange(true)}

--- a/src/app/(app)/invoice/__tests__/InvoiceWorkspace.test.tsx
+++ b/src/app/(app)/invoice/__tests__/InvoiceWorkspace.test.tsx
@@ -168,6 +168,7 @@ describe('InvoiceWorkspace', () => {
       vi.mocked(parseInvoiceHash).mockResolvedValue({
         success: true,
         data: VALID_INVOICE,
+        contentHash: 'mock-content-hash',
       })
 
       render(<InvoiceWorkspace />)
@@ -183,6 +184,7 @@ describe('InvoiceWorkspace', () => {
       vi.mocked(parseInvoiceHash).mockResolvedValue({
         success: true,
         data: VALID_INVOICE,
+        contentHash: 'mock-content-hash',
       })
 
       render(<InvoiceWorkspace />)
@@ -190,6 +192,7 @@ describe('InvoiceWorkspace', () => {
       await waitFor(() => {
         expect(mockStoreState.trackView).toHaveBeenCalledWith(
           expect.objectContaining({
+            contentHash: expect.any(String),
             invoiceId: 'INV-001',
             source: 'created',
             viewedAt: expect.any(String),
@@ -251,6 +254,7 @@ describe('InvoiceWorkspace', () => {
       vi.mocked(parseInvoiceHash).mockResolvedValue({
         success: true,
         data: VALID_INVOICE,
+        contentHash: 'mock-content-hash',
       })
 
       render(<InvoiceWorkspace />)
@@ -265,6 +269,7 @@ describe('InvoiceWorkspace', () => {
       vi.mocked(parseInvoiceHash).mockResolvedValue({
         success: true,
         data: VALID_INVOICE,
+        contentHash: 'mock-content-hash',
       })
 
       render(<InvoiceWorkspace />)
@@ -283,6 +288,7 @@ describe('InvoiceWorkspace', () => {
       vi.mocked(parseInvoiceHash).mockResolvedValue({
         success: true,
         data: VALID_INVOICE,
+        contentHash: 'mock-content-hash',
       })
 
       render(<InvoiceWorkspace />)

--- a/src/app/(app)/pay/PayWorkspace.tsx
+++ b/src/app/(app)/pay/PayWorkspace.tsx
@@ -111,7 +111,7 @@ interface PayWorkspaceReadyProps {
 function PayWorkspaceReady({ invoice, payInvoice }: PayWorkspaceReadyProps) {
   const {
     panelStatus, source, dismissError, txHash, confirmations, storedError,
-    finalized, exactTotal, subtotal, polling, verifyTxHash, isSyncing,
+    finalized, exactTotal, subtotal, polling, verifyTxHash, isSyncing, contentHash,
   } = payInvoice
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false)
@@ -141,7 +141,7 @@ function PayWorkspaceReady({ invoice, payInvoice }: PayWorkspaceReadyProps) {
       {txHash && !finalized && (
         <PaymentVerifier
           invoice={invoice}
-          invoiceId={invoice.invoiceId}
+          contentHash={contentHash}
           txHash={txHash}
           exactTotal={exactTotal}
           onReorgDetected={polling.startAutoCheck}
@@ -221,7 +221,7 @@ function PayWorkspaceReady({ invoice, payInvoice }: PayWorkspaceReadyProps) {
                     ) : (
                       <PayButton
                         invoice={invoice}
-                        invoiceId={invoice.invoiceId}
+                        contentHash={contentHash}
                         exactTotal={exactTotal}
                         subtotal={subtotal}
                         onSuccess={handlePaymentSuccess}

--- a/src/app/(app)/pay/PayWorkspace.tsx
+++ b/src/app/(app)/pay/PayWorkspace.tsx
@@ -190,6 +190,7 @@ function PayWorkspaceReady({ invoice, payInvoice }: PayWorkspaceReadyProps) {
                 {isPaid && txHash ? (
                   <PaymentPanel
                     invoice={invoice}
+                    contentHash={contentHash}
                     status={panelStatus}
                     txHash={txHash}
                     source={source}
@@ -200,6 +201,7 @@ function PayWorkspaceReady({ invoice, payInvoice }: PayWorkspaceReadyProps) {
                 ) : (
                   <PaymentPanel
                     invoice={invoice}
+                    contentHash={contentHash}
                     status={panelStatus}
                     source={source}
                     {...(paymentError ? { error: paymentError } : storedError ? { error: storedError } : {})}
@@ -240,7 +242,7 @@ function PayWorkspaceReady({ invoice, payInvoice }: PayWorkspaceReadyProps) {
                 >
                   <ChevronDownIcon size={14} />
                 </button>
-                <DevStatusToggle invoiceId={invoice.invoiceId} status={panelStatus} />
+                <DevStatusToggle contentHash={contentHash} status={panelStatus} />
                 <DevPaymentStepToggle onChange={setDevPaymentStep} />
               </motion.div>
             )}

--- a/src/app/(app)/pay/PaymentVerifier.tsx
+++ b/src/app/(app)/pay/PaymentVerifier.tsx
@@ -6,7 +6,7 @@ import type { Invoice } from '@/shared/lib/invoice-types'
 
 interface PaymentVerifierProps {
   invoice: Invoice
-  invoiceId: string
+  contentHash: string
   txHash: `0x${string}`
   exactTotal: string
   onReorgDetected?: (() => void) | undefined
@@ -21,7 +21,7 @@ interface PaymentVerifierProps {
 function VerificationEffect(props: PaymentVerifierProps) {
   usePaymentVerification(props)
   useFinalizationTracker({
-    invoiceId: props.invoiceId,
+    contentHash: props.contentHash,
     txHash: props.txHash,
     networkId: props.invoice.networkId,
     onReorgDetected: props.onReorgDetected,

--- a/src/app/(app)/pay/__tests__/PayWorkspace.test.tsx
+++ b/src/app/(app)/pay/__tests__/PayWorkspace.test.tsx
@@ -124,6 +124,7 @@ describe('PayWorkspace', () => {
         vi.mocked(parseInvoiceHash).mockResolvedValue({
           success: true,
           data: VALID_INVOICE,
+          contentHash: 'mock-content-hash',
         })
 
         render(<PayWorkspace />)
@@ -139,6 +140,7 @@ describe('PayWorkspace', () => {
         vi.mocked(parseInvoiceHash).mockResolvedValue({
           success: true,
           data: VALID_INVOICE,
+          contentHash: 'mock-content-hash',
         })
 
         render(<PayWorkspace />)
@@ -156,6 +158,7 @@ describe('PayWorkspace', () => {
         vi.mocked(parseInvoiceHash).mockResolvedValue({
           success: true,
           data: { ...VALID_INVOICE, networkId: 42161 }, // Arbitrum
+          contentHash: 'mock-content-hash',
         })
 
         render(<PayWorkspace />)
@@ -172,6 +175,7 @@ describe('PayWorkspace', () => {
         vi.mocked(parseInvoiceHash).mockResolvedValue({
           success: true,
           data: { ...VALID_INVOICE, networkId: 1 }, // Ethereum
+          contentHash: 'mock-content-hash',
         })
 
         render(<PayWorkspace />)
@@ -191,6 +195,7 @@ describe('PayWorkspace', () => {
       vi.mocked(parseInvoiceHash).mockResolvedValue({
         success: true,
         data: VALID_INVOICE,
+        contentHash: 'mock-content-hash',
       })
 
       render(<PayWorkspace />)
@@ -218,6 +223,7 @@ describe('PayWorkspace', () => {
       vi.mocked(parseInvoiceHash).mockResolvedValue({
         success: true,
         data: VALID_INVOICE,
+        contentHash: 'mock-content-hash',
       })
 
       render(<PayWorkspace />)
@@ -343,6 +349,7 @@ describe('PayWorkspace', () => {
       vi.mocked(parseInvoiceHash).mockResolvedValue({
         success: true,
         data: VALID_INVOICE,
+        contentHash: 'mock-content-hash',
       })
       mockGetInvoice.mockReturnValue(undefined)
 
@@ -351,6 +358,7 @@ describe('PayWorkspace', () => {
       await waitFor(() => {
         expect(mockStoreState.trackView).toHaveBeenCalledWith(
           expect.objectContaining({
+            contentHash: expect.any(String),
             invoiceId: 'INV-001',
             source: 'received',
             viewedAt: expect.any(String),
@@ -365,6 +373,7 @@ describe('PayWorkspace', () => {
       vi.mocked(parseInvoiceHash).mockResolvedValue({
         success: true,
         data: VALID_INVOICE,
+        contentHash: 'mock-content-hash',
       })
       mockGetInvoice.mockReturnValue({
         invoiceId: 'INV-001',
@@ -381,6 +390,7 @@ describe('PayWorkspace', () => {
 
       expect(mockStoreState.trackView).toHaveBeenCalledWith(
         expect.objectContaining({
+          contentHash: expect.any(String),
           invoiceId: 'INV-001',
           source: 'received',
         })

--- a/src/app/history/HistoryWorkspace.tsx
+++ b/src/app/history/HistoryWorkspace.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useTrackedInvoiceStore } from '@/entities/invoice'
 import { parseInvoiceHash } from '@/features/invoice-codec'
@@ -11,6 +12,26 @@ import { Loader2Icon } from '@/shared/ui/icons'
 import { HistorySkeleton } from './HistorySkeleton'
 import { useReceivedInvoices } from './use-received-invoices'
 import { useCreatedInvoices } from './use-created-invoices'
+
+/**
+ * Reactive hydration hook — subscribes to onFinishHydration so React
+ * knows when to re-render after async persist migration completes.
+ * Unlike persist.hasHydrated() (a non-reactive getter), this triggers re-render.
+ */
+function useStoreHydrated(): boolean {
+  const [hydrated, setHydrated] = useState(
+    useTrackedInvoiceStore.persist.hasHydrated(),
+  )
+
+  useEffect(() => {
+    const unsub = useTrackedInvoiceStore.persist.onFinishHydration(() => {
+      setHydrated(true)
+    })
+    return unsub
+  }, [])
+
+  return hydrated
+}
 
 async function decodeInvoiceUrl(url: string): Promise<DecodedBatchInvoice | null> {
   try {
@@ -33,7 +54,7 @@ async function decodeInvoiceUrl(url: string): Promise<DecodedBatchInvoice | null
 export function HistoryWorkspace() {
   const debug = process.env.NODE_ENV === 'development'
 
-  const trackedHydrated = useTrackedInvoiceStore.persist.hasHydrated()
+  const trackedHydrated = useStoreHydrated()
 
   const { createdCount, pendingCount } = useTrackedInvoiceStore(
     useShallow((s) => {

--- a/src/app/history/__tests__/use-received-invoices.test.ts
+++ b/src/app/history/__tests__/use-received-invoices.test.ts
@@ -27,6 +27,7 @@ const mockParseInvoiceHash = vi.mocked(parseInvoiceHash)
 const mockComputeInvoiceStatus = vi.mocked(computeInvoiceStatus)
 
 const makeTracked = (overrides?: Record<string, unknown>) => ({
+  contentHash: (overrides?.contentHash as string) ?? 'abc123hash',
   invoiceId: 'INV-001',
   invoiceUrl: 'https://voidpay.xyz/pay#abc123',
   source: 'received' as const,
@@ -191,8 +192,8 @@ describe('useReceivedInvoices', () => {
   it('decodes multiple received invoices', async () => {
     useTrackedInvoiceStore.setState({
       invoices: [
-        makeTracked({ invoiceId: 'INV-001', invoiceUrl: 'https://voidpay.xyz/pay#hash1' }),
-        makeTracked({ invoiceId: 'INV-002', invoiceUrl: 'https://voidpay.xyz/pay#hash2' }),
+        makeTracked({ contentHash: 'hash1', invoiceId: 'INV-001', invoiceUrl: 'https://voidpay.xyz/pay#hash1' }),
+        makeTracked({ contentHash: 'hash2', invoiceId: 'INV-002', invoiceUrl: 'https://voidpay.xyz/pay#hash2' }),
       ],
     })
 

--- a/src/entities/invoice/lib/__tests__/compute-status.test.ts
+++ b/src/entities/invoice/lib/__tests__/compute-status.test.ts
@@ -17,6 +17,7 @@ const mockIsDueDatePassed = vi.mocked(isDueDatePassed)
 
 function makeTracked(overrides: Partial<TrackedInvoice> = {}): TrackedInvoice {
   return {
+    contentHash: 'test-001-hash',
     invoiceId: 'inv-test-001',
     invoiceUrl: 'https://voidpay.xyz/pay#abc',
     source: 'received',

--- a/src/entities/invoice/model/__tests__/rich-invoice-store.test.ts
+++ b/src/entities/invoice/model/__tests__/rich-invoice-store.test.ts
@@ -13,11 +13,13 @@ describe('useTrackedInvoiceStore', () => {
   })
 
   function createMockTrackedInvoice(
-    overrides: Partial<Omit<TrackedInvoice, 'createdAt'>> = {}
+    overrides: Partial<Omit<TrackedInvoice, 'createdAt'>> = {},
+    contentHash: string = 'abc123hash',
   ): Omit<TrackedInvoice, 'createdAt'> {
     return {
+      contentHash,
       invoiceId: 'INV-001',
-      invoiceUrl: 'https://voidpay.xyz/pay#abc123',
+      invoiceUrl: `https://voidpay.xyz/pay#${contentHash}`,
       source: 'received' as const,
       ...overrides,
     }
@@ -38,6 +40,7 @@ describe('useTrackedInvoiceStore', () => {
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(1)
+      expect(state.invoices[0].contentHash).toBe('abc123hash')
       expect(state.invoices[0].invoiceId).toBe('INV-001')
     })
 
@@ -54,37 +57,37 @@ describe('useTrackedInvoiceStore', () => {
     it('prepends new invoices to list', () => {
       const { addInvoice } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'FIRST' }))
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'SECOND' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'FIRST' }, 'hash1'))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'SECOND' }, 'hash2'))
 
       const state = useTrackedInvoiceStore.getState()
-      expect(state.invoices[0].invoiceId).toBe('SECOND')
-      expect(state.invoices[1].invoiceId).toBe('FIRST')
+      expect(state.invoices[0].contentHash).toBe('hash2')
+      expect(state.invoices[1].contentHash).toBe('hash1')
     })
 
     it('merge-upserts existing invoice and moves to top (source immutable)', () => {
       const { addInvoice } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'EXISTING', source: 'received' }))
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'OTHER' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'EXISTING', source: 'received' }, 'existing-hash'))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'OTHER' }, 'other-hash'))
 
       // Re-add with different source — original source preserved (first-write-wins)
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'EXISTING', source: 'created' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'EXISTING', source: 'created' }, 'existing-hash'))
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(2)
-      expect(state.invoices[0].invoiceId).toBe('EXISTING')
+      expect(state.invoices[0].contentHash).toBe('existing-hash')
       expect(state.invoices[0].source).toBe('received')
     })
 
     it('preserves existing createdAt on upsert', () => {
       const { addInvoice } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'PRESERVE' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'PRESERVE' }, 'preserve-hash'))
       const originalCreatedAt = useTrackedInvoiceStore.getState().invoices[0].createdAt
 
       // Re-add same invoice
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'PRESERVE' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'PRESERVE' }, 'preserve-hash'))
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].createdAt).toBe(originalCreatedAt)
@@ -93,11 +96,11 @@ describe('useTrackedInvoiceStore', () => {
     it('resets payment fields on upsert (W3-013 hardening)', () => {
       const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-TX' }))
-      setTxHash('MERGE-TX', `0x${'a'.repeat(64)}`)
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-TX' }, 'merge-tx-hash'))
+      setTxHash('merge-tx-hash', `0x${'a'.repeat(64)}`)
 
       // Re-add same invoice — payment fields MUST be reset (W3-013)
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-TX', invoiceUrl: 'https://voidpay.xyz/pay#updated' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-TX', invoiceUrl: 'https://voidpay.xyz/pay#updated' }, 'merge-tx-hash'))
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].txHash).toBeUndefined()
@@ -108,12 +111,20 @@ describe('useTrackedInvoiceStore', () => {
       const { addInvoice } = useTrackedInvoiceStore.getState()
 
       for (let i = 0; i < 55; i++) {
-        addInvoice(createMockTrackedInvoice({ invoiceId: `INV-${i.toString().padStart(3, '0')}` }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: `INV-${i.toString().padStart(3, '0')}` }, `hash-${i.toString().padStart(3, '0')}`))
       }
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(50)
       expect(state.invoices[0].invoiceId).toBe('INV-054')
+    })
+
+    it('allows different invoices with same invoiceId but different contentHash', () => {
+      const { addInvoice } = useTrackedInvoiceStore.getState()
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'INV-2026-001' }, 'senderA-hash'))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'INV-2026-001' }, 'senderB-hash'))
+      const state = useTrackedInvoiceStore.getState()
+      expect(state.invoices).toHaveLength(2)
     })
   })
 
@@ -121,9 +132,9 @@ describe('useTrackedInvoiceStore', () => {
     it('sets transaction hash', () => {
       const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'TX-TEST' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'TX-TEST' }, 'tx-test-hash'))
 
-      setTxHash('TX-TEST', `0x${'ab'.repeat(32)}`)
+      setTxHash('tx-test-hash', `0x${'ab'.repeat(32)}`)
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].txHash).toBe(`0x${'ab'.repeat(32)}`)
@@ -132,8 +143,8 @@ describe('useTrackedInvoiceStore', () => {
     it('does not set status field (no status on TrackedInvoice)', () => {
       const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'TX-NO-STATUS' }))
-      setTxHash('TX-NO-STATUS', `0x${'cd'.repeat(32)}`)
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'TX-NO-STATUS' }, 'tx-no-status-hash'))
+      setTxHash('tx-no-status-hash', `0x${'cd'.repeat(32)}`)
 
       const state = useTrackedInvoiceStore.getState()
       // TrackedInvoice has no status field
@@ -143,9 +154,9 @@ describe('useTrackedInvoiceStore', () => {
     it('sets validation flag', () => {
       const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'VALIDATED' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'VALIDATED' }, 'validated-hash'))
 
-      setTxHash('VALIDATED', `0x${'ef'.repeat(32)}`, true)
+      setTxHash('validated-hash', `0x${'ef'.repeat(32)}`, true)
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].txHashValidated).toBe(true)
@@ -154,9 +165,9 @@ describe('useTrackedInvoiceStore', () => {
     it('defaults validation to false', () => {
       const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'UNVALIDATED' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'UNVALIDATED' }, 'unvalidated-hash'))
 
-      setTxHash('UNVALIDATED', `0x${'12'.repeat(32)}`)
+      setTxHash('unvalidated-hash', `0x${'12'.repeat(32)}`)
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].txHashValidated).toBe(false)
@@ -165,8 +176,8 @@ describe('useTrackedInvoiceStore', () => {
     it('sets paidAt when validated is true', () => {
       const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'PAID-AT' }))
-      setTxHash('PAID-AT', `0x${'34'.repeat(32)}`, true)
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'PAID-AT' }, 'paid-at-hash'))
+      setTxHash('paid-at-hash', `0x${'34'.repeat(32)}`, true)
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].paidAt).toBeDefined()
@@ -176,8 +187,8 @@ describe('useTrackedInvoiceStore', () => {
     it('does not set paidAt when validated is false', () => {
       const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'NO-PAID-AT' }))
-      setTxHash('NO-PAID-AT', `0x${'56'.repeat(32)}`, false)
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'NO-PAID-AT' }, 'no-paid-at-hash'))
+      setTxHash('no-paid-at-hash', `0x${'56'.repeat(32)}`, false)
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].paidAt).toBeUndefined()
@@ -186,13 +197,13 @@ describe('useTrackedInvoiceStore', () => {
     it('preserves existing paidAt when re-calling with validated=false', () => {
       const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'PRESERVE-PAID' }))
-      setTxHash('PRESERVE-PAID', `0x${'78'.repeat(32)}`, true)
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'PRESERVE-PAID' }, 'preserve-paid-hash'))
+      setTxHash('preserve-paid-hash', `0x${'78'.repeat(32)}`, true)
 
       const paidAt = useTrackedInvoiceStore.getState().invoices[0].paidAt
       expect(paidAt).toBeDefined()
 
-      setTxHash('PRESERVE-PAID', `0x${'9a'.repeat(32)}`, false)
+      setTxHash('preserve-paid-hash', `0x${'9a'.repeat(32)}`, false)
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].paidAt).toBe(paidAt)
@@ -204,11 +215,11 @@ describe('useTrackedInvoiceStore', () => {
       const { addInvoice, setTxHash, setConfirmations, resetPaymentState } =
         useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'RESET-TEST' }))
-      setTxHash('RESET-TEST', `0x${'bc'.repeat(32)}`, true)
-      setConfirmations('RESET-TEST', { current: 6, required: 12 })
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'RESET-TEST' }, 'reset-test-hash'))
+      setTxHash('reset-test-hash', `0x${'bc'.repeat(32)}`, true)
+      setConfirmations('reset-test-hash', { current: 6, required: 12 })
 
-      resetPaymentState('RESET-TEST')
+      resetPaymentState('reset-test-hash')
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].txHash).toBeUndefined()
@@ -226,12 +237,12 @@ describe('useTrackedInvoiceStore', () => {
           invoiceId: 'PRESERVE-FIELDS',
           invoiceUrl: 'https://voidpay.xyz/pay#preserve',
           source: 'created',
-        })
+        }, 'preserve-fields-hash')
       )
-      setTxHash('PRESERVE-FIELDS', `0x${'de'.repeat(32)}`, true)
-      setError('PRESERVE-FIELDS', 'some error')
+      setTxHash('preserve-fields-hash', `0x${'de'.repeat(32)}`, true)
+      setError('preserve-fields-hash', 'some error')
 
-      resetPaymentState('PRESERVE-FIELDS')
+      resetPaymentState('preserve-fields-hash')
 
       const state = useTrackedInvoiceStore.getState()
       const inv = state.invoices[0]
@@ -242,12 +253,12 @@ describe('useTrackedInvoiceStore', () => {
       expect(inv.createdAt).toBeDefined()
     })
 
-    it('handles non-existent invoiceId gracefully', () => {
+    it('handles non-existent contentHash gracefully', () => {
       const { addInvoice, resetPaymentState } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'KEEP' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'KEEP' }, 'keep-hash'))
 
-      resetPaymentState('NON-EXISTENT')
+      resetPaymentState('non-existent-hash')
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(1)
@@ -256,24 +267,24 @@ describe('useTrackedInvoiceStore', () => {
   })
 
   describe('removeInvoice', () => {
-    it('removes invoice by invoiceId', () => {
+    it('removes invoice by contentHash', () => {
       const { addInvoice, removeInvoice } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'TO-REMOVE' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'TO-REMOVE' }, 'to-remove-hash'))
       expect(useTrackedInvoiceStore.getState().invoices).toHaveLength(1)
 
-      removeInvoice('TO-REMOVE')
+      removeInvoice('to-remove-hash')
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(0)
     })
 
-    it('handles non-existent invoiceId gracefully', () => {
+    it('handles non-existent contentHash gracefully', () => {
       const { addInvoice, removeInvoice } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'KEEP' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'KEEP' }, 'keep-hash'))
 
-      removeInvoice('NON-EXISTENT')
+      removeInvoice('non-existent-hash')
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(1)
@@ -282,34 +293,35 @@ describe('useTrackedInvoiceStore', () => {
     it('removes only specified invoice', () => {
       const { addInvoice, removeInvoice } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'FIRST' }))
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'SECOND' }))
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'THIRD' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'FIRST' }, 'first-hash'))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'SECOND' }, 'second-hash'))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'THIRD' }, 'third-hash'))
 
-      removeInvoice('SECOND')
+      removeInvoice('second-hash')
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(2)
-      expect(state.invoices.map((i) => i.invoiceId)).toEqual(['THIRD', 'FIRST'])
+      expect(state.invoices.map((i) => i.contentHash)).toEqual(['third-hash', 'first-hash'])
     })
   })
 
   describe('getInvoice', () => {
-    it('returns invoice by invoiceId', () => {
+    it('returns invoice by contentHash', () => {
       const { addInvoice, getInvoice } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'FIND-ME' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'FIND-ME' }, 'find-me-hash'))
 
-      const invoice = getInvoice('FIND-ME')
+      const invoice = getInvoice('find-me-hash')
 
       expect(invoice).toBeDefined()
+      expect(invoice?.contentHash).toBe('find-me-hash')
       expect(invoice?.invoiceId).toBe('FIND-ME')
     })
 
-    it('returns undefined for non-existent invoiceId', () => {
+    it('returns undefined for non-existent contentHash', () => {
       const { getInvoice } = useTrackedInvoiceStore.getState()
 
-      const invoice = getInvoice('NON-EXISTENT')
+      const invoice = getInvoice('non-existent-hash')
 
       expect(invoice).toBeUndefined()
     })
@@ -319,9 +331,9 @@ describe('useTrackedInvoiceStore', () => {
     it('removes all invoices', () => {
       const { addInvoice, clearAll } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'ONE' }))
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'TWO' }))
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'THREE' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'ONE' }, 'one-hash'))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'TWO' }, 'two-hash'))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'THREE' }, 'three-hash'))
 
       expect(useTrackedInvoiceStore.getState().invoices).toHaveLength(3)
 
@@ -336,8 +348,8 @@ describe('useTrackedInvoiceStore', () => {
     it('sets confirmation progress', () => {
       const { addInvoice, setConfirmations } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'CONFIRM-TEST' }))
-      setConfirmations('CONFIRM-TEST', { current: 3, required: 12 })
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'CONFIRM-TEST' }, 'confirm-test-hash'))
+      setConfirmations('confirm-test-hash', { current: 3, required: 12 })
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].confirmations).toEqual({ current: 3, required: 12 })
@@ -346,19 +358,19 @@ describe('useTrackedInvoiceStore', () => {
     it('clears confirmations when undefined', () => {
       const { addInvoice, setConfirmations } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'CLEAR-CONFIRM' }))
-      setConfirmations('CLEAR-CONFIRM', { current: 5, required: 12 })
-      setConfirmations('CLEAR-CONFIRM', undefined)
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'CLEAR-CONFIRM' }, 'clear-confirm-hash'))
+      setConfirmations('clear-confirm-hash', { current: 5, required: 12 })
+      setConfirmations('clear-confirm-hash', undefined)
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].confirmations).toBeUndefined()
     })
 
-    it('handles non-existent invoiceId gracefully', () => {
+    it('handles non-existent contentHash gracefully', () => {
       const { addInvoice, setConfirmations } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'EXIST' }))
-      setConfirmations('NON-EXISTENT', { current: 1, required: 12 })
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'EXIST' }, 'exist-hash'))
+      setConfirmations('non-existent-hash', { current: 1, required: 12 })
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].confirmations).toBeUndefined()
@@ -369,8 +381,8 @@ describe('useTrackedInvoiceStore', () => {
     it('sets error message', () => {
       const { addInvoice, setError } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'ERROR-TEST' }))
-      setError('ERROR-TEST', 'Transaction reverted')
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'ERROR-TEST' }, 'error-test-hash'))
+      setError('error-test-hash', 'Transaction reverted')
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].error).toBe('Transaction reverted')
@@ -379,20 +391,20 @@ describe('useTrackedInvoiceStore', () => {
     it('clears error with null (converts to undefined via store)', () => {
       const { addInvoice, setError } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'CLEAR-ERROR' }))
-      setError('CLEAR-ERROR', 'Some error')
-      setError('CLEAR-ERROR', null)
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'CLEAR-ERROR' }, 'clear-error-hash'))
+      setError('clear-error-hash', 'Some error')
+      setError('clear-error-hash', null)
 
       const state = useTrackedInvoiceStore.getState()
       // error field stores null as passed — callers treat null as "no error"
       expect(state.invoices[0].error).toBeNull()
     })
 
-    it('handles non-existent invoiceId gracefully', () => {
+    it('handles non-existent contentHash gracefully', () => {
       const { addInvoice, setError } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'EXIST' }))
-      setError('NON-EXISTENT', 'Error')
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'EXIST' }, 'exist-hash'))
+      setError('non-existent-hash', 'Error')
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices[0].error).toBeUndefined()
@@ -407,7 +419,7 @@ describe('useTrackedInvoiceStore', () => {
         createMockTrackedInvoice({
           invoiceId: 'CREATED-SOURCE',
           source: 'created',
-        })
+        }, 'created-source-hash')
       )
 
       const state = useTrackedInvoiceStore.getState()
@@ -418,6 +430,7 @@ describe('useTrackedInvoiceStore', () => {
       const { addInvoice } = useTrackedInvoiceStore.getState()
 
       addInvoice({
+        contentHash: 'full-options-hash',
         invoiceId: 'FULL-OPTIONS',
         invoiceUrl: 'https://voidpay.xyz/pay#full',
         source: 'received',
@@ -439,15 +452,15 @@ describe('useTrackedInvoiceStore', () => {
       const { addInvoice, setTxHash, removeInvoice } = useTrackedInvoiceStore.getState()
 
       for (let i = 0; i < 10; i++) {
-        addInvoice(createMockTrackedInvoice({ invoiceId: `RAPID-${i}` }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: `RAPID-${i}` }, `rapid-hash-${i}`))
       }
 
       for (let i = 0; i < 5; i++) {
-        setTxHash(`RAPID-${i}`, `0x${i.toString().padStart(2, '0').repeat(32)}`, true)
+        setTxHash(`rapid-hash-${i}`, `0x${i.toString().padStart(2, '0').repeat(32)}`, true)
       }
 
       for (let i = 5; i < 8; i++) {
-        removeInvoice(`RAPID-${i}`)
+        removeInvoice(`rapid-hash-${i}`)
       }
 
       const state = useTrackedInvoiceStore.getState()
@@ -461,14 +474,15 @@ describe('useTrackedInvoiceStore', () => {
       const { addInvoice, setTxHash, getInvoice } = useTrackedInvoiceStore.getState()
 
       addInvoice({
+        contentHash: 'integrity-hash',
         invoiceId: 'INTEGRITY-TEST',
         invoiceUrl: 'https://voidpay.xyz/pay#integrity',
         source: 'received',
       })
 
-      setTxHash('INTEGRITY-TEST', `0x${'aa'.repeat(32)}`, true)
+      setTxHash('integrity-hash', `0x${'aa'.repeat(32)}`, true)
 
-      const invoice = getInvoice('INTEGRITY-TEST')
+      const invoice = getInvoice('integrity-hash')
       expect(invoice?.invoiceId).toBe('INTEGRITY-TEST')
       expect(invoice?.invoiceUrl).toBe('https://voidpay.xyz/pay#integrity')
       expect(invoice?.source).toBe('received')
@@ -483,6 +497,7 @@ describe('useTrackedInvoiceStore', () => {
       const { trackView } = useTrackedInvoiceStore.getState()
 
       trackView({
+        contentHash: 'new-view-hash',
         invoiceId: 'NEW-VIEW',
         invoiceUrl: 'https://voidpay.xyz/pay#hash',
         source: 'received',
@@ -491,6 +506,7 @@ describe('useTrackedInvoiceStore', () => {
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(1)
+      expect(state.invoices[0].contentHash).toBe('new-view-hash')
       expect(state.invoices[0].invoiceId).toBe('NEW-VIEW')
       expect(state.invoices[0].source).toBe('received')
       expect(state.invoices[0].viewedAt).toBe('2026-03-10T12:00:00Z')
@@ -504,12 +520,13 @@ describe('useTrackedInvoiceStore', () => {
       const { addInvoice, setTxHash, setValidated, setFinalized, trackView } =
         useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'PAID-VIEW' }))
-      setTxHash('PAID-VIEW', `0x${'ab'.repeat(32)}`, false)
-      setValidated('PAID-VIEW', true)
-      setFinalized('PAID-VIEW')
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'PAID-VIEW' }, 'paid-view-hash'))
+      setTxHash('paid-view-hash', `0x${'ab'.repeat(32)}`, false)
+      setValidated('paid-view-hash', true)
+      setFinalized('paid-view-hash')
 
       trackView({
+        contentHash: 'paid-view-hash',
         invoiceId: 'PAID-VIEW',
         invoiceUrl: 'https://voidpay.xyz/pay#updated',
         source: 'received',
@@ -529,12 +546,13 @@ describe('useTrackedInvoiceStore', () => {
       const { addInvoice, setTxHash, setConfirmations, setError, trackView } =
         useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'CONFIRM-VIEW' }))
-      setTxHash('CONFIRM-VIEW', `0x${'cd'.repeat(32)}`, false)
-      setConfirmations('CONFIRM-VIEW', { current: 2, required: 3 })
-      setError('CONFIRM-VIEW', 'some error')
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'CONFIRM-VIEW' }, 'confirm-view-hash'))
+      setTxHash('confirm-view-hash', `0x${'cd'.repeat(32)}`, false)
+      setConfirmations('confirm-view-hash', { current: 2, required: 3 })
+      setError('confirm-view-hash', 'some error')
 
       trackView({
+        contentHash: 'confirm-view-hash',
         invoiceId: 'CONFIRM-VIEW',
         invoiceUrl: 'https://voidpay.xyz/pay#hash',
         source: 'received',
@@ -550,9 +568,10 @@ describe('useTrackedInvoiceStore', () => {
     it('preserves original source on re-view (first-write-wins)', () => {
       const { addInvoice, trackView } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'SRC', source: 'created' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'SRC', source: 'created' }, 'src-hash'))
 
       trackView({
+        contentHash: 'src-hash',
         invoiceId: 'SRC',
         invoiceUrl: 'https://voidpay.xyz/pay#hash',
         source: 'received',
@@ -565,30 +584,32 @@ describe('useTrackedInvoiceStore', () => {
     it('moves viewed invoice to top of list (MRU order)', () => {
       const { addInvoice, trackView } = useTrackedInvoiceStore.getState()
 
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'A' }))
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'B' }))
-      addInvoice(createMockTrackedInvoice({ invoiceId: 'C' }))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'A' }, 'a-hash'))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'B' }, 'b-hash'))
+      addInvoice(createMockTrackedInvoice({ invoiceId: 'C' }, 'c-hash'))
       // Order: C, B, A
 
       trackView({
+        contentHash: 'a-hash',
         invoiceId: 'A',
         invoiceUrl: 'https://voidpay.xyz/pay#hash',
         source: 'received',
         viewedAt: '2026-03-10T17:00:00Z',
       })
 
-      const ids = useTrackedInvoiceStore.getState().invoices.map(i => i.invoiceId)
-      expect(ids[0]).toBe('A')
+      const ids = useTrackedInvoiceStore.getState().invoices.map(i => i.contentHash)
+      expect(ids[0]).toBe('a-hash')
     })
 
     it('respects MAX_INVOICES limit', () => {
       const { addInvoice, trackView } = useTrackedInvoiceStore.getState()
 
       for (let i = 0; i < 50; i++) {
-        addInvoice(createMockTrackedInvoice({ invoiceId: `FILL-${i}` }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: `FILL-${i}` }, `fill-hash-${i}`))
       }
 
       trackView({
+        contentHash: 'overflow-hash',
         invoiceId: 'OVERFLOW',
         invoiceUrl: 'https://voidpay.xyz/pay#hash',
         source: 'received',
@@ -597,100 +618,100 @@ describe('useTrackedInvoiceStore', () => {
 
       const state = useTrackedInvoiceStore.getState()
       expect(state.invoices).toHaveLength(50)
-      expect(state.invoices[0].invoiceId).toBe('OVERFLOW')
+      expect(state.invoices[0].contentHash).toBe('overflow-hash')
     })
   })
 
   describe('store hardening', () => {
     // W3-013: addInvoice merge-upsert must NOT inherit stale payment fields
     describe('addInvoice resets payment fields on upsert (W3-013)', () => {
-      it('clears txHash when re-adding same invoice id', () => {
+      it('clears txHash when re-adding same contentHash', () => {
         const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-POISON' }))
-        setTxHash('MERGE-POISON', `0x${'a'.repeat(64)}` as `0x${string}`, false)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-POISON' }, 'merge-poison-hash'))
+        setTxHash('merge-poison-hash', `0x${'a'.repeat(64)}` as `0x${string}`, false)
 
         // Re-add same invoice (simulating URL re-open / update)
         addInvoice(
           createMockTrackedInvoice({
             invoiceId: 'MERGE-POISON',
             invoiceUrl: 'https://voidpay.xyz/pay#updated',
-          })
+          }, 'merge-poison-hash')
         )
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'MERGE-POISON')!
+        const inv = state.invoices.find((i) => i.contentHash === 'merge-poison-hash')!
         expect(inv.txHash).toBeUndefined()
       })
 
-      it('clears txHashValidated when re-adding same invoice id', () => {
+      it('clears txHashValidated when re-adding same contentHash', () => {
         const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-VALIDATED' }))
-        setTxHash('MERGE-VALIDATED', `0x${'b'.repeat(64)}` as `0x${string}`, true)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-VALIDATED' }, 'merge-validated-hash'))
+        setTxHash('merge-validated-hash', `0x${'b'.repeat(64)}` as `0x${string}`, true)
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-VALIDATED' }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-VALIDATED' }, 'merge-validated-hash'))
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'MERGE-VALIDATED')!
+        const inv = state.invoices.find((i) => i.contentHash === 'merge-validated-hash')!
         expect(inv.txHashValidated).toBeUndefined()
       })
 
-      it('clears paidAt when re-adding same invoice id', () => {
+      it('clears paidAt when re-adding same contentHash', () => {
         const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-PAIDAT' }))
-        setTxHash('MERGE-PAIDAT', `0x${'c'.repeat(64)}` as `0x${string}`, true)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-PAIDAT' }, 'merge-paidat-hash'))
+        setTxHash('merge-paidat-hash', `0x${'c'.repeat(64)}` as `0x${string}`, true)
 
         // Sanity: paidAt is set
         expect(useTrackedInvoiceStore.getState().invoices[0].paidAt).toBeDefined()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-PAIDAT' }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-PAIDAT' }, 'merge-paidat-hash'))
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'MERGE-PAIDAT')!
+        const inv = state.invoices.find((i) => i.contentHash === 'merge-paidat-hash')!
         expect(inv.paidAt).toBeUndefined()
       })
 
-      it('clears finalized when re-adding same invoice id', () => {
+      it('clears finalized when re-adding same contentHash', () => {
         const { addInvoice, setTxHash, setValidated, setFinalized } =
           useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-FINALIZED' }))
-        setTxHash('MERGE-FINALIZED', `0x${'d'.repeat(64)}` as `0x${string}`)
-        setValidated('MERGE-FINALIZED', true)
-        setFinalized('MERGE-FINALIZED')
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-FINALIZED' }, 'merge-finalized-hash'))
+        setTxHash('merge-finalized-hash', `0x${'d'.repeat(64)}` as `0x${string}`)
+        setValidated('merge-finalized-hash', true)
+        setFinalized('merge-finalized-hash')
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-FINALIZED' }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-FINALIZED' }, 'merge-finalized-hash'))
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'MERGE-FINALIZED')!
+        const inv = state.invoices.find((i) => i.contentHash === 'merge-finalized-hash')!
         expect(inv.finalized).toBeUndefined()
       })
 
-      it('clears confirmations when re-adding same invoice id', () => {
+      it('clears confirmations when re-adding same contentHash', () => {
         const { addInvoice, setConfirmations } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-CONFIRM' }))
-        setConfirmations('MERGE-CONFIRM', { current: 6, required: 12 })
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-CONFIRM' }, 'merge-confirm-hash'))
+        setConfirmations('merge-confirm-hash', { current: 6, required: 12 })
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-CONFIRM' }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-CONFIRM' }, 'merge-confirm-hash'))
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'MERGE-CONFIRM')!
+        const inv = state.invoices.find((i) => i.contentHash === 'merge-confirm-hash')!
         expect(inv.confirmations).toBeUndefined()
       })
 
-      it('clears error when re-adding same invoice id', () => {
+      it('clears error when re-adding same contentHash', () => {
         const { addInvoice, setError } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-ERROR' }))
-        setError('MERGE-ERROR', 'some error from previous payment attempt')
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-ERROR' }, 'merge-error-hash'))
+        setError('merge-error-hash', 'some error from previous payment attempt')
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-ERROR' }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-ERROR' }, 'merge-error-hash'))
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'MERGE-ERROR')!
+        const inv = state.invoices.find((i) => i.contentHash === 'merge-error-hash')!
         // error must be reset to undefined on re-open — no stale state leak
         expect(inv.error).toBeUndefined()
       })
@@ -698,7 +719,7 @@ describe('useTrackedInvoiceStore', () => {
       it('still preserves createdAt and updates non-payment fields on upsert', () => {
         const { addInvoice } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-PRESERVE', source: 'created' }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'MERGE-PRESERVE', source: 'created' }, 'merge-preserve-hash'))
         const originalCreatedAt = useTrackedInvoiceStore.getState().invoices[0].createdAt
 
         addInvoice(
@@ -706,11 +727,11 @@ describe('useTrackedInvoiceStore', () => {
             invoiceId: 'MERGE-PRESERVE',
             source: 'received',
             invoiceUrl: 'https://voidpay.xyz/pay#newurl',
-          })
+          }, 'merge-preserve-hash')
         )
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'MERGE-PRESERVE')!
+        const inv = state.invoices.find((i) => i.contentHash === 'merge-preserve-hash')!
         expect(inv.source).toBe('created') // source is immutable (first-write-wins)
         expect(inv.invoiceUrl).toBe('https://voidpay.xyz/pay#newurl')
         expect(inv.createdAt).toBe(originalCreatedAt)
@@ -722,38 +743,38 @@ describe('useTrackedInvoiceStore', () => {
       it('does not set txHashValidated when invoice has no txHash', () => {
         const { addInvoice, setValidated } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'VALIDATE-NO-TX' }))
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'VALIDATE-NO-TX' }, 'validate-no-tx-hash'))
 
         // Guard: invoice has no txHash — setValidated should be a no-op
-        setValidated('VALIDATE-NO-TX', true)
+        setValidated('validate-no-tx-hash', true)
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'VALIDATE-NO-TX')!
+        const inv = state.invoices.find((i) => i.contentHash === 'validate-no-tx-hash')!
         expect(inv.txHashValidated).toBeUndefined()
       })
 
       it('does not set paidAt when invoice has no txHash', () => {
         const { addInvoice, setValidated } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'VALIDATE-NO-PAIDAT' }))
-        setValidated('VALIDATE-NO-PAIDAT', true)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'VALIDATE-NO-PAIDAT' }, 'validate-no-paidat-hash'))
+        setValidated('validate-no-paidat-hash', true)
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'VALIDATE-NO-PAIDAT')!
+        const inv = state.invoices.find((i) => i.contentHash === 'validate-no-paidat-hash')!
         expect(inv.paidAt).toBeUndefined()
       })
 
       it('sets txHashValidated when invoice already has txHash', () => {
         const { addInvoice, setTxHash, setValidated } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'VALIDATE-WITH-TX' }))
-        setTxHash('VALIDATE-WITH-TX', `0x${'e'.repeat(64)}` as `0x${string}`)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'VALIDATE-WITH-TX' }, 'validate-with-tx-hash'))
+        setTxHash('validate-with-tx-hash', `0x${'e'.repeat(64)}` as `0x${string}`)
 
         // Now setValidated should work because txHash is present
-        setValidated('VALIDATE-WITH-TX', true)
+        setValidated('validate-with-tx-hash', true)
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'VALIDATE-WITH-TX')!
+        const inv = state.invoices.find((i) => i.contentHash === 'validate-with-tx-hash')!
         expect(inv.txHashValidated).toBe(true)
         expect(inv.paidAt).toBeDefined()
       })
@@ -763,22 +784,22 @@ describe('useTrackedInvoiceStore', () => {
       it('rejects non-hex string (not 0x-prefixed)', () => {
         const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-NOHEX' }))
-        setTxHash('FORMAT-NOHEX', 'not-a-hash' as any)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-NOHEX' }, 'format-nohex-hash'))
+        setTxHash('format-nohex-hash', 'not-a-hash' as any)
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'FORMAT-NOHEX')!
+        const inv = state.invoices.find((i) => i.contentHash === 'format-nohex-hash')!
         expect(inv.txHash).toBeUndefined()
       })
 
       it('rejects hash that is too short (< 66 chars)', () => {
         const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-SHORT' }))
-        setTxHash('FORMAT-SHORT', '0x123' as any)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-SHORT' }, 'format-short-hash'))
+        setTxHash('format-short-hash', '0x123' as any)
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'FORMAT-SHORT')!
+        const inv = state.invoices.find((i) => i.contentHash === 'format-short-hash')!
         expect(inv.txHash).toBeUndefined()
       })
 
@@ -786,11 +807,11 @@ describe('useTrackedInvoiceStore', () => {
         const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
         const validHash = `0x${'a'.repeat(64)}` as `0x${string}`
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-VALID' }))
-        setTxHash('FORMAT-VALID', validHash)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-VALID' }, 'format-valid-hash'))
+        setTxHash('format-valid-hash', validHash)
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'FORMAT-VALID')!
+        const inv = state.invoices.find((i) => i.contentHash === 'format-valid-hash')!
         expect(inv.txHash).toBe(validHash)
       })
 
@@ -798,22 +819,22 @@ describe('useTrackedInvoiceStore', () => {
         const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
         const validHash = `0x${'A'.repeat(64)}` as `0x${string}`
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-UPPER' }))
-        setTxHash('FORMAT-UPPER', validHash)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-UPPER' }, 'format-upper-hash'))
+        setTxHash('format-upper-hash', validHash)
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'FORMAT-UPPER')!
+        const inv = state.invoices.find((i) => i.contentHash === 'format-upper-hash')!
         expect(inv.txHash).toBe(validHash)
       })
 
       it('rejects hash that is too long (> 66 chars)', () => {
         const { addInvoice, setTxHash } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-LONG' }))
-        setTxHash('FORMAT-LONG', `0x${'a'.repeat(65)}` as any)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'FORMAT-LONG' }, 'format-long-hash'))
+        setTxHash('format-long-hash', `0x${'a'.repeat(65)}` as any)
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'FORMAT-LONG')!
+        const inv = state.invoices.find((i) => i.contentHash === 'format-long-hash')!
         expect(inv.txHash).toBeUndefined()
       })
     })
@@ -822,25 +843,25 @@ describe('useTrackedInvoiceStore', () => {
       it('does not set finalized when invoice is not validated', () => {
         const { addInvoice, setTxHash, setFinalized } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'FINALIZE-UNVALIDATED' }))
-        setTxHash('FINALIZE-UNVALIDATED', `0x${'f'.repeat(64)}` as `0x${string}`)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'FINALIZE-UNVALIDATED' }, 'finalize-unvalidated-hash'))
+        setTxHash('finalize-unvalidated-hash', `0x${'f'.repeat(64)}` as `0x${string}`)
         // txHashValidated is false — setFinalized must be a no-op
 
-        setFinalized('FINALIZE-UNVALIDATED')
+        setFinalized('finalize-unvalidated-hash')
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'FINALIZE-UNVALIDATED')!
+        const inv = state.invoices.find((i) => i.contentHash === 'finalize-unvalidated-hash')!
         expect(inv.finalized).toBeUndefined()
       })
 
       it('does not set finalized when invoice has no txHash at all', () => {
         const { addInvoice, setFinalized } = useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'FINALIZE-NOTX' }))
-        setFinalized('FINALIZE-NOTX')
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'FINALIZE-NOTX' }, 'finalize-notx-hash'))
+        setFinalized('finalize-notx-hash')
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'FINALIZE-NOTX')!
+        const inv = state.invoices.find((i) => i.contentHash === 'finalize-notx-hash')!
         expect(inv.finalized).toBeUndefined()
       })
 
@@ -848,22 +869,22 @@ describe('useTrackedInvoiceStore', () => {
         const { addInvoice, setTxHash, setValidated, setFinalized } =
           useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'FINALIZE-OK' }))
-        setTxHash('FINALIZE-OK', `0x${'1'.repeat(64)}` as `0x${string}`)
-        setValidated('FINALIZE-OK', true)
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'FINALIZE-OK' }, 'finalize-ok-hash'))
+        setTxHash('finalize-ok-hash', `0x${'1'.repeat(64)}` as `0x${string}`)
+        setValidated('finalize-ok-hash', true)
 
-        setFinalized('FINALIZE-OK')
+        setFinalized('finalize-ok-hash')
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'FINALIZE-OK')!
+        const inv = state.invoices.find((i) => i.contentHash === 'finalize-ok-hash')!
         expect(inv.finalized).toBe(true)
       })
 
-      it('handles non-existent invoiceId gracefully', () => {
+      it('handles non-existent contentHash gracefully', () => {
         const { setFinalized } = useTrackedInvoiceStore.getState()
 
         // Should not throw
-        expect(() => setFinalized('NON-EXISTENT')).not.toThrow()
+        expect(() => setFinalized('non-existent-hash')).not.toThrow()
       })
     })
 
@@ -872,23 +893,23 @@ describe('useTrackedInvoiceStore', () => {
         const { addInvoice, setTxHash, setValidated, setFinalized, resetPaymentState } =
           useTrackedInvoiceStore.getState()
 
-        addInvoice(createMockTrackedInvoice({ invoiceId: 'RESET-FINALIZED' }))
-        setTxHash('RESET-FINALIZED', `0x${'2'.repeat(64)}` as `0x${string}`)
-        setValidated('RESET-FINALIZED', true)
-        setFinalized('RESET-FINALIZED')
+        addInvoice(createMockTrackedInvoice({ invoiceId: 'RESET-FINALIZED' }, 'reset-finalized-hash'))
+        setTxHash('reset-finalized-hash', `0x${'2'.repeat(64)}` as `0x${string}`)
+        setValidated('reset-finalized-hash', true)
+        setFinalized('reset-finalized-hash')
 
         // Sanity: all payment fields are set
         const before = useTrackedInvoiceStore
           .getState()
-          .invoices.find((i) => i.invoiceId === 'RESET-FINALIZED')!
+          .invoices.find((i) => i.contentHash === 'reset-finalized-hash')!
         expect(before.txHash).toBeDefined()
         expect(before.txHashValidated).toBe(true)
         expect(before.finalized).toBe(true)
 
-        resetPaymentState('RESET-FINALIZED')
+        resetPaymentState('reset-finalized-hash')
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'RESET-FINALIZED')!
+        const inv = state.invoices.find((i) => i.contentHash === 'reset-finalized-hash')!
         expect(inv.txHash).toBeUndefined()
         expect(inv.txHashValidated).toBeUndefined()
         expect(inv.paidAt).toBeUndefined()
@@ -905,16 +926,16 @@ describe('useTrackedInvoiceStore', () => {
             invoiceId: 'RESET-PRESERVE2',
             invoiceUrl: 'https://voidpay.xyz/pay#preserve2',
             source: 'created',
-          })
+          }, 'reset-preserve2-hash')
         )
-        setTxHash('RESET-PRESERVE2', `0x${'3'.repeat(64)}` as `0x${string}`)
-        setValidated('RESET-PRESERVE2', true)
-        setFinalized('RESET-PRESERVE2')
+        setTxHash('reset-preserve2-hash', `0x${'3'.repeat(64)}` as `0x${string}`)
+        setValidated('reset-preserve2-hash', true)
+        setFinalized('reset-preserve2-hash')
 
-        resetPaymentState('RESET-PRESERVE2')
+        resetPaymentState('reset-preserve2-hash')
 
         const state = useTrackedInvoiceStore.getState()
-        const inv = state.invoices.find((i) => i.invoiceId === 'RESET-PRESERVE2')!
+        const inv = state.invoices.find((i) => i.contentHash === 'reset-preserve2-hash')!
         expect(inv.invoiceId).toBe('RESET-PRESERVE2')
         expect(inv.invoiceUrl).toBe('https://voidpay.xyz/pay#preserve2')
         expect(inv.source).toBe('created')

--- a/src/entities/invoice/model/rich-invoice-store.ts
+++ b/src/entities/invoice/model/rich-invoice-store.ts
@@ -164,6 +164,7 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
         const exists = get().invoices.some(inv => inv.contentHash === contentHash)
         if (!exists) {
           console.warn('[TrackedInvoiceStore] setTxHash called for unknown invoice:', { contentHash, txHash })
+          return
         }
         set((state) => ({
           invoices: state.invoices.map((inv) =>
@@ -272,13 +273,15 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
           }
 
           if (version === 1) {
-            // Inline SHA-256 to avoid FSD violation (entities can't import features)
+            // Inline SHA-256 to avoid FSD violation (entities can't import features).
+            // Must stay frozen at SHA-256 — future algorithm changes go in new versions.
             const sha256 = async (input: string): Promise<string> => {
               const data = new TextEncoder().encode(input)
               const buf = await crypto.subtle.digest('SHA-256', data)
               return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('')
             }
-            const migrated = await Promise.all(
+            // Use allSettled so one corrupted entry does not destroy the entire store
+            const results = await Promise.allSettled(
               (state.invoices as Array<Record<string, unknown>>).map(async (inv) => {
                 const url = (inv.invoiceUrl as string) ?? ''
                 const hashIndex = url.indexOf('#')
@@ -287,11 +290,16 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
                 return { ...inv, contentHash } as TrackedInvoice
               })
             )
-            return { invoices: migrated.filter((inv) => inv.contentHash !== '') }
+            const migrated = results
+              .filter((r): r is PromiseFulfilledResult<TrackedInvoice> => r.status === 'fulfilled')
+              .map((r) => r.value)
+              .filter((inv) => inv.contentHash !== '')
+            return { invoices: migrated }
           }
 
           return { invoices: state.invoices as TrackedInvoice[] }
-        } catch {
+        } catch (e) {
+          console.warn('[TrackedInvoiceStore] Migration failed, resetting store:', e)
           return { invoices: [] }
         }
       },

--- a/src/entities/invoice/model/rich-invoice-store.ts
+++ b/src/entities/invoice/model/rich-invoice-store.ts
@@ -265,36 +265,20 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
     {
       name: INVOICE_VIEW_STORE_KEY,
       version: 2,
-      migrate: async (persisted, version): Promise<TrackedInvoiceState> => {
+      migrate: (persisted, version): TrackedInvoiceState => {
         try {
           const state = persisted as Record<string, unknown>
           if (!state || typeof state !== 'object' || !Array.isArray(state.invoices)) {
             return { invoices: [] }
           }
 
-          if (version === 1) {
-            // Inline SHA-256 to avoid FSD violation (entities can't import features).
-            // Must stay frozen at SHA-256 — future algorithm changes go in new versions.
-            const sha256 = async (input: string): Promise<string> => {
-              const data = new TextEncoder().encode(input)
-              const buf = await crypto.subtle.digest('SHA-256', data)
-              return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('')
-            }
-            // Use allSettled so one corrupted entry does not destroy the entire store
-            const results = await Promise.allSettled(
-              (state.invoices as Array<Record<string, unknown>>).map(async (inv) => {
-                const url = (inv.invoiceUrl as string) ?? ''
-                const hashIndex = url.indexOf('#')
-                const fragment = hashIndex === -1 ? '' : url.slice(hashIndex + 1)
-                const contentHash = fragment ? await sha256(fragment) : ''
-                return { ...inv, contentHash } as TrackedInvoice
-              })
-            )
-            const migrated = results
-              .filter((r): r is PromiseFulfilledResult<TrackedInvoice> => r.status === 'fulfilled')
-              .map((r) => r.value)
-              .filter((inv) => inv.contentHash !== '')
-            return { invoices: migrated }
+          if (version < 2) {
+            console.info('[TrackedInvoiceStore] Migrating v%d → v2: %d invoices', version, state.invoices.length)
+            const invoices = (state.invoices as Array<Record<string, unknown>>).map((inv) => ({
+              ...inv,
+              contentHash: '',
+            })) as TrackedInvoice[]
+            return { invoices }
           }
 
           return { invoices: state.invoices as TrackedInvoice[] }
@@ -307,11 +291,70 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
   )
 )
 
-// Cross-tab sync: rehydrate store when another tab updates localStorage
-if (typeof window !== 'undefined') {
-  window.addEventListener('storage', (e) => {
-    if (e.key === INVOICE_VIEW_STORE_KEY) {
-      void useTrackedInvoiceStore.persist.rehydrate()
-    }
-  })
+// ---------------------------------------------------------------------------
+// Post-hydration: compute contentHash for v1→v2 migrated invoices
+// ---------------------------------------------------------------------------
+
+// Inline SHA-256 — frozen at SHA-256, future changes go in new versions.
+const _sha256 = async (input: string): Promise<string> => {
+  const data = new TextEncoder().encode(input)
+  const buf = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('')
 }
+
+function _computeMissingContentHashes(): void {
+  const { invoices } = useTrackedInvoiceStore.getState()
+  const needsHash = invoices.filter((inv) => !inv.contentHash)
+  if (needsHash.length === 0) return
+
+  console.info('[TrackedInvoiceStore] Computing contentHash for %d invoices post-hydration', needsHash.length)
+
+  void (async () => {
+    const results = await Promise.allSettled(
+      needsHash.map(async (inv) => {
+        const url = inv.invoiceUrl ?? ''
+        const hashIndex = url.indexOf('#')
+        const fragment = hashIndex === -1 ? '' : url.slice(hashIndex + 1)
+        if (!fragment) return null
+        const contentHash = await _sha256(fragment)
+        return { ...inv, contentHash } as TrackedInvoice
+      }),
+    )
+
+    const computed = new Map<string, TrackedInvoice>()
+    for (const r of results) {
+      if (r.status === 'fulfilled' && r.value && r.value.contentHash) {
+        computed.set(r.value.invoiceUrl, r.value)
+      }
+    }
+
+    const current = useTrackedInvoiceStore.getState()
+    const updated = current.invoices
+      .map((inv) => {
+        if (inv.contentHash) return inv
+        return computed.get(inv.invoiceUrl) ?? inv
+      })
+      .filter((inv) => inv.contentHash !== '')
+
+    useTrackedInvoiceStore.setState({ invoices: updated })
+    console.info(
+      '[TrackedInvoiceStore] contentHash computation complete: %d computed, %d dropped',
+      computed.size,
+      needsHash.length - computed.size,
+    )
+  })()
+}
+
+if (typeof window !== 'undefined') {
+  useTrackedInvoiceStore.persist.onFinishHydration(_computeMissingContentHashes)
+  // Sync migration + sync storage = hydration completes during create().
+  // onFinishHydration registered after → listener missed the event. Run manually.
+  if (useTrackedInvoiceStore.persist.hasHydrated()) {
+    _computeMissingContentHashes()
+  }
+}
+
+// Cross-tab sync removed: rehydrate() re-triggers migration from stale tabs
+// that still write version 1. Will be re-added with BroadcastChannel after
+// migration period is over (all users on v2).
+// See: https://github.com/pmndrs/zustand/pull/3336

--- a/src/entities/invoice/model/rich-invoice-store.ts
+++ b/src/entities/invoice/model/rich-invoice-store.ts
@@ -113,9 +113,8 @@ interface TrackedInvoiceStore extends TrackedInvoiceState {
   resetPaymentState: (contentHash: string) => void
 }
 
-// Set by migrate() when v1→v2 runs; signals post-hydration hash computation.
-// Declared before create() because migrate() executes during store creation.
-let _pendingHashComputation = false
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex } from '@noble/hashes/utils.js'
 
 /**
  * Hook to access tracked invoices store
@@ -277,11 +276,16 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
           }
 
           if (version < 2) {
-            _pendingHashComputation = true
-            const invoices = (state.invoices as Array<Record<string, unknown>>).map((inv) => ({
-              ...inv,
-              contentHash: '',
-            })) as TrackedInvoice[]
+            const invoices = (state.invoices as Array<Record<string, unknown>>)
+              .map((inv) => {
+                const url = (inv.invoiceUrl as string) ?? ''
+                const hashIndex = url.indexOf('#')
+                const fragment = hashIndex === -1 ? '' : url.slice(hashIndex + 1)
+                if (!fragment) return null
+                const contentHash = bytesToHex(sha256(new TextEncoder().encode(fragment)))
+                return { ...inv, contentHash } as TrackedInvoice
+              })
+              .filter((inv): inv is TrackedInvoice => inv !== null)
             return { invoices }
           }
 
@@ -294,67 +298,6 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
     }
   )
 )
-
-// ---------------------------------------------------------------------------
-// Post-hydration: compute contentHash for v1→v2 migrated invoices
-// Only runs when migrate() sets the flag — skipped on v2+ stores.
-// ---------------------------------------------------------------------------
-
-// Inline SHA-256 — frozen at SHA-256, future changes go in new versions.
-const _sha256 = async (input: string): Promise<string> => {
-  const data = new TextEncoder().encode(input)
-  const buf = await crypto.subtle.digest('SHA-256', data)
-  return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('')
-}
-
-function _computeMissingContentHashes(): void {
-  if (!_pendingHashComputation) return
-  _pendingHashComputation = false
-
-  const { invoices } = useTrackedInvoiceStore.getState()
-  const needsHash = invoices.filter((inv) => !inv.contentHash)
-  if (needsHash.length === 0) return
-
-
-  void (async () => {
-    const results = await Promise.allSettled(
-      needsHash.map(async (inv) => {
-        const url = inv.invoiceUrl ?? ''
-        const hashIndex = url.indexOf('#')
-        const fragment = hashIndex === -1 ? '' : url.slice(hashIndex + 1)
-        if (!fragment) return null
-        const contentHash = await _sha256(fragment)
-        return { ...inv, contentHash } as TrackedInvoice
-      }),
-    )
-
-    const computed = new Map<string, TrackedInvoice>()
-    for (const r of results) {
-      if (r.status === 'fulfilled' && r.value && r.value.contentHash) {
-        computed.set(r.value.invoiceUrl, r.value)
-      }
-    }
-
-    const current = useTrackedInvoiceStore.getState()
-    const updated = current.invoices
-      .map((inv) => {
-        if (inv.contentHash) return inv
-        return computed.get(inv.invoiceUrl) ?? inv
-      })
-      .filter((inv) => inv.contentHash !== '')
-
-    useTrackedInvoiceStore.setState({ invoices: updated })
-  })()
-}
-
-if (typeof window !== 'undefined') {
-  useTrackedInvoiceStore.persist.onFinishHydration(_computeMissingContentHashes)
-  // Sync migration + sync storage = hydration completes during create().
-  // onFinishHydration registered after → listener missed the event. Run manually.
-  if (useTrackedInvoiceStore.persist.hasHydrated()) {
-    _computeMissingContentHashes()
-  }
-}
 
 // Cross-tab sync removed: rehydrate() re-triggers migration from stale tabs
 // that still write version 1. Will be re-added with BroadcastChannel after

--- a/src/entities/invoice/model/rich-invoice-store.ts
+++ b/src/entities/invoice/model/rich-invoice-store.ts
@@ -113,6 +113,10 @@ interface TrackedInvoiceStore extends TrackedInvoiceState {
   resetPaymentState: (contentHash: string) => void
 }
 
+// Set by migrate() when v1→v2 runs; signals post-hydration hash computation.
+// Declared before create() because migrate() executes during store creation.
+let _pendingHashComputation = false
+
 /**
  * Hook to access tracked invoices store
  */
@@ -273,6 +277,7 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
           }
 
           if (version < 2) {
+            _pendingHashComputation = true
             console.info('[TrackedInvoiceStore] Migrating v%d → v2: %d invoices', version, state.invoices.length)
             const invoices = (state.invoices as Array<Record<string, unknown>>).map((inv) => ({
               ...inv,
@@ -293,6 +298,7 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
 
 // ---------------------------------------------------------------------------
 // Post-hydration: compute contentHash for v1→v2 migrated invoices
+// Only runs when migrate() sets the flag — skipped on v2+ stores.
 // ---------------------------------------------------------------------------
 
 // Inline SHA-256 — frozen at SHA-256, future changes go in new versions.
@@ -303,6 +309,9 @@ const _sha256 = async (input: string): Promise<string> => {
 }
 
 function _computeMissingContentHashes(): void {
+  if (!_pendingHashComputation) return
+  _pendingHashComputation = false
+
   const { invoices } = useTrackedInvoiceStore.getState()
   const needsHash = invoices.filter((inv) => !inv.contentHash)
   if (needsHash.length === 0) return

--- a/src/entities/invoice/model/rich-invoice-store.ts
+++ b/src/entities/invoice/model/rich-invoice-store.ts
@@ -278,7 +278,6 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
 
           if (version < 2) {
             _pendingHashComputation = true
-            console.info('[TrackedInvoiceStore] Migrating v%d → v2: %d invoices', version, state.invoices.length)
             const invoices = (state.invoices as Array<Record<string, unknown>>).map((inv) => ({
               ...inv,
               contentHash: '',
@@ -316,7 +315,6 @@ function _computeMissingContentHashes(): void {
   const needsHash = invoices.filter((inv) => !inv.contentHash)
   if (needsHash.length === 0) return
 
-  console.info('[TrackedInvoiceStore] Computing contentHash for %d invoices post-hydration', needsHash.length)
 
   void (async () => {
     const results = await Promise.allSettled(
@@ -346,11 +344,6 @@ function _computeMissingContentHashes(): void {
       .filter((inv) => inv.contentHash !== '')
 
     useTrackedInvoiceStore.setState({ invoices: updated })
-    console.info(
-      '[TrackedInvoiceStore] contentHash computation complete: %d computed, %d dropped',
-      computed.size,
-      needsHash.length - computed.size,
-    )
   })()
 }
 

--- a/src/entities/invoice/model/rich-invoice-store.ts
+++ b/src/entities/invoice/model/rich-invoice-store.ts
@@ -16,6 +16,8 @@ export type InvoiceSource = 'created' | 'received'
  * A tracked invoice entry
  */
 export interface TrackedInvoice {
+  /** SHA-256 content hash — unique storage key derived from URL fragment (bytes32-compatible) */
+  contentHash: string
   /** Unique invoice ID from the invoice data */
   invoiceId: string
   /** Generated URL for sharing */
@@ -52,13 +54,13 @@ const MAX_INVOICES = 50
 // Allows undefined values for optional fields (needed for exactOptionalPropertyTypes)
 type UpsertData = {
   [K in keyof TrackedInvoice]?: TrackedInvoice[K] | undefined
-} & { invoiceId: string }
+} & { contentHash: string; invoiceId: string }
 
 function _upsertInvoice(
   invoices: TrackedInvoice[],
   data: UpsertData,
 ): TrackedInvoice[] {
-  const existing = invoices.find((inv) => inv.invoiceId === data.invoiceId)
+  const existing = invoices.find((inv) => inv.contentHash === data.contentHash)
   const base = {
     ...existing,
     ...data,
@@ -68,20 +70,21 @@ function _upsertInvoice(
   }
 
   if (!base.invoiceUrl || !base.source) {
-    console.warn('[TrackedInvoiceStore] Skipping upsert: missing required fields', data.invoiceId)
+    console.warn('[TrackedInvoiceStore] Skipping upsert: missing required fields', data.contentHash)
     return invoices
   }
 
   // Safe: required fields verified by guard above, optional undefined fields are valid at runtime
   const merged = {
     ...base,
+    contentHash: base.contentHash,
     invoiceId: base.invoiceId,
     invoiceUrl: base.invoiceUrl,
     source: base.source,
     createdAt: base.createdAt,
   } as TrackedInvoice
 
-  const filtered = invoices.filter((inv) => inv.invoiceId !== data.invoiceId)
+  const filtered = invoices.filter((inv) => inv.contentHash !== data.contentHash)
   return [merged, ...filtered].slice(0, MAX_INVOICES)
 }
 
@@ -93,20 +96,21 @@ interface TrackedInvoiceStore extends TrackedInvoiceState {
   // actions:
   addInvoice: (invoice: Omit<TrackedInvoice, 'createdAt'>) => void
   trackView: (data: {
+    contentHash: string
     invoiceId: string
     invoiceUrl: string
     source: InvoiceSource
     viewedAt: string
   }) => void
-  setTxHash: (invoiceId: string, txHash: `0x${string}`, validated?: boolean) => void
-  setValidated: (invoiceId: string, validated: boolean) => void
-  setFinalized: (invoiceId: string) => void
-  setConfirmations: (invoiceId: string, confirmations?: ConfirmationProgress) => void
-  setError: (invoiceId: string, error: string | null) => void
-  getInvoice: (invoiceId: string) => TrackedInvoice | undefined
-  removeInvoice: (invoiceId: string) => void
+  setTxHash: (contentHash: string, txHash: `0x${string}`, validated?: boolean) => void
+  setValidated: (contentHash: string, validated: boolean) => void
+  setFinalized: (contentHash: string) => void
+  setConfirmations: (contentHash: string, confirmations?: ConfirmationProgress) => void
+  setError: (contentHash: string, error: string | null) => void
+  getInvoice: (contentHash: string) => TrackedInvoice | undefined
+  removeInvoice: (contentHash: string) => void
   clearAll: () => void
-  resetPaymentState: (invoiceId: string) => void
+  resetPaymentState: (contentHash: string) => void
 }
 
 /**
@@ -120,7 +124,7 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
       addInvoice: (invoice) => {
         set((state) => {
           const existing = state.invoices.find(
-            (inv) => inv.invoiceId === invoice.invoiceId
+            (inv) => inv.contentHash === invoice.contentHash
           )
           // W3-013: reset payment-critical fields on merge to prevent stale state
           const safeDefaults = {
@@ -143,21 +147,27 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
 
       trackView: (data) => {
         set((state) => ({
-          invoices: _upsertInvoice(state.invoices, data),
+          invoices: _upsertInvoice(state.invoices, {
+            contentHash: data.contentHash,
+            invoiceId: data.invoiceId,
+            invoiceUrl: data.invoiceUrl,
+            source: data.source,
+            viewedAt: data.viewedAt,
+          }),
         }))
       },
 
-      setTxHash: (invoiceId, txHash, validated = false) => {
+      setTxHash: (contentHash, txHash, validated = false) => {
         const TX_HASH_REGEX = /^0x[a-fA-F0-9]{64}$/
         if (!TX_HASH_REGEX.test(txHash)) return
 
-        const exists = get().invoices.some(inv => inv.invoiceId === invoiceId)
+        const exists = get().invoices.some(inv => inv.contentHash === contentHash)
         if (!exists) {
-          console.warn('[TrackedInvoiceStore] setTxHash called for unknown invoice:', { invoiceId, txHash })
+          console.warn('[TrackedInvoiceStore] setTxHash called for unknown invoice:', { contentHash, txHash })
         }
         set((state) => ({
           invoices: state.invoices.map((inv) =>
-            inv.invoiceId === invoiceId
+            inv.contentHash === contentHash
               ? {
                   ...inv,
                   txHash,
@@ -169,14 +179,14 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
         }))
       },
 
-      setValidated: (invoiceId, validated) => {
+      setValidated: (contentHash, validated) => {
         // W3-014: guard against missing txHash
-        const invoice = get().invoices.find(inv => inv.invoiceId === invoiceId)
+        const invoice = get().invoices.find(inv => inv.contentHash === contentHash)
         if (!invoice?.txHash) return
 
         set((state) => ({
           invoices: state.invoices.map((inv) =>
-            inv.invoiceId === invoiceId
+            inv.contentHash === contentHash
               ? {
                   ...inv,
                   txHashValidated: validated,
@@ -187,22 +197,22 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
         }))
       },
 
-      setFinalized: (invoiceId) => {
-        const invoice = get().invoices.find(inv => inv.invoiceId === invoiceId)
+      setFinalized: (contentHash) => {
+        const invoice = get().invoices.find(inv => inv.contentHash === contentHash)
         if (!invoice?.txHashValidated) return
         set((state) => ({
           invoices: state.invoices.map((inv) =>
-            inv.invoiceId === invoiceId
+            inv.contentHash === contentHash
               ? { ...inv, finalized: true }
               : inv
           ),
         }))
       },
 
-      setConfirmations: (invoiceId, confirmations) => {
+      setConfirmations: (contentHash, confirmations) => {
         set((state) => ({
           invoices: state.invoices.map((inv) => {
-            if (inv.invoiceId !== invoiceId) return inv
+            if (inv.contentHash !== contentHash) return inv
             if (confirmations === undefined) {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               const { confirmations: _c, ...rest } = inv
@@ -216,34 +226,34 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
         }))
       },
 
-      setError: (invoiceId, error) => {
+      setError: (contentHash, error) => {
         set((state) => ({
           invoices: state.invoices.map((inv) =>
-            inv.invoiceId === invoiceId
+            inv.contentHash === contentHash
               ? { ...inv, error }
               : inv
           ),
         }))
       },
 
-      removeInvoice: (invoiceId) => {
+      removeInvoice: (contentHash) => {
         set((state) => ({
-          invoices: state.invoices.filter((inv) => inv.invoiceId !== invoiceId),
+          invoices: state.invoices.filter((inv) => inv.contentHash !== contentHash),
         }))
       },
 
-      getInvoice: (invoiceId) => {
-        return get().invoices.find((inv) => inv.invoiceId === invoiceId)
+      getInvoice: (contentHash) => {
+        return get().invoices.find((inv) => inv.contentHash === contentHash)
       },
 
       clearAll: () => {
         set({ invoices: [] })
       },
 
-      resetPaymentState: (invoiceId) => {
+      resetPaymentState: (contentHash) => {
         set((state) => ({
           invoices: state.invoices.map((inv) => {
-            if (inv.invoiceId !== invoiceId) return inv
+            if (inv.contentHash !== contentHash) return inv
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { txHash, txHashValidated, paidAt, confirmations, finalized, ...rest } = inv
             return rest
@@ -253,13 +263,33 @@ export const useTrackedInvoiceStore = create<TrackedInvoiceStore>()(
     }),
     {
       name: INVOICE_VIEW_STORE_KEY,
-      version: 1,
-      migrate: (persisted): TrackedInvoiceState => {
+      version: 2,
+      migrate: async (persisted, version): Promise<TrackedInvoiceState> => {
         try {
           const state = persisted as Record<string, unknown>
           if (!state || typeof state !== 'object' || !Array.isArray(state.invoices)) {
             return { invoices: [] }
           }
+
+          if (version === 1) {
+            // Inline SHA-256 to avoid FSD violation (entities can't import features)
+            const sha256 = async (input: string): Promise<string> => {
+              const data = new TextEncoder().encode(input)
+              const buf = await crypto.subtle.digest('SHA-256', data)
+              return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('')
+            }
+            const migrated = await Promise.all(
+              (state.invoices as Array<Record<string, unknown>>).map(async (inv) => {
+                const url = (inv.invoiceUrl as string) ?? ''
+                const hashIndex = url.indexOf('#')
+                const fragment = hashIndex === -1 ? '' : url.slice(hashIndex + 1)
+                const contentHash = fragment ? await sha256(fragment) : ''
+                return { ...inv, contentHash } as TrackedInvoice
+              })
+            )
+            return { invoices: migrated.filter((inv) => inv.contentHash !== '') }
+          }
+
           return { invoices: state.invoices as TrackedInvoice[] }
         } catch {
           return { invoices: [] }

--- a/src/features/data-export/model/__tests__/export.test.ts
+++ b/src/features/data-export/model/__tests__/export.test.ts
@@ -37,6 +37,7 @@ describe('exportUserData', () => {
   it('includes tracked invoices', () => {
     useTrackedInvoiceStore.setState({
       invoices: [{
+        contentHash: 'test-hash',
         invoiceId: 'INV-001',
         invoiceUrl: 'https://voidpay.xyz/pay#test',
         source: 'created',

--- a/src/features/data-export/model/__tests__/import.test.ts
+++ b/src/features/data-export/model/__tests__/import.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useCreatorStore } from '@/entities/creator'
 import { useTrackedInvoiceStore } from '@/entities/invoice'
 import { importUserData } from '../import'
+
+// Mock computeContentHash used by import for legacy entries without contentHash
+vi.mock('@/features/invoice-codec', () => ({
+  computeContentHash: vi.fn((fragment: string) => Promise.resolve(`${fragment}-computed-hash`)),
+}))
 
 describe('importUserData', () => {
   beforeEach(() => {
@@ -26,6 +31,7 @@ describe('importUserData', () => {
     trackedInvoices: {
       invoices: [
         {
+          contentHash: 'abc-hash',
           invoiceId: 'INV-001',
           invoiceUrl: 'https://voidpay.xyz/pay#abc',
           source: 'created' as const,
@@ -35,8 +41,8 @@ describe('importUserData', () => {
     },
   }
 
-  it('returns success with stats on valid import', () => {
-    const result = importUserData(validImport)
+  it('returns success with stats on valid import', async () => {
+    const result = await importUserData(validImport)
 
     expect(result.success).toBe(true)
     expect(result.stats).toEqual({
@@ -46,44 +52,44 @@ describe('importUserData', () => {
     })
   })
 
-  it('merges preferences from import', () => {
-    importUserData(validImport)
+  it('merges preferences from import', async () => {
+    await importUserData(validImport)
 
     const { preferences } = useCreatorStore.getState()
     expect(preferences.includeOgImage).toBe(false)
   })
 
-  it('imports tracked invoices', () => {
-    importUserData(validImport)
+  it('imports tracked invoices', async () => {
+    await importUserData(validImport)
 
     const { invoices } = useTrackedInvoiceStore.getState()
     expect(invoices.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('handles import without trackedInvoices', () => {
+  it('handles import without trackedInvoices', async () => {
     const { trackedInvoices: _, ...withoutTracked } = validImport
-    const result = importUserData(withoutTracked)
+    const result = await importUserData(withoutTracked)
 
     expect(result.success).toBe(true)
     expect(result.stats?.trackedInvoices).toBe(0)
   })
 
-  it('returns error on invalid data', () => {
-    const result = importUserData({ invalid: true })
+  it('returns error on invalid data', async () => {
+    const result = await importUserData({ invalid: true })
 
     expect(result.success).toBe(false)
     expect(result.error).toBeDefined()
   })
 
-  it('returns error on null input', () => {
-    const result = importUserData(null)
+  it('returns error on null input', async () => {
+    const result = await importUserData(null)
 
     expect(result.success).toBe(false)
     expect(result.error).toBeDefined()
   })
 
-  it('returns error on wrong version', () => {
-    const result = importUserData({ ...validImport, version: 99 })
+  it('returns error on wrong version', async () => {
+    const result = await importUserData({ ...validImport, version: 99 })
 
     expect(result.success).toBe(false)
   })

--- a/src/features/data-export/model/__tests__/import.test.ts
+++ b/src/features/data-export/model/__tests__/import.test.ts
@@ -5,7 +5,7 @@ import { importUserData } from '../import'
 
 // Mock computeContentHash used by import for legacy entries without contentHash
 vi.mock('@/features/invoice-codec', () => ({
-  computeContentHash: vi.fn((fragment: string) => Promise.resolve(`${fragment}-computed-hash`)),
+  computeContentHash: vi.fn((fragment: string) => `${fragment}-computed-hash`),
 }))
 
 describe('importUserData', () => {

--- a/src/features/data-export/model/import.ts
+++ b/src/features/data-export/model/import.ts
@@ -72,16 +72,14 @@ export const importUserData = async (data: unknown): Promise<ImportResult> => {
     if (validData.trackedInvoices?.invoices) {
       const { addInvoice } = useTrackedInvoiceStore.getState()
       // Always derive contentHash from URL — never trust pre-supplied values
-      const enriched = await Promise.all(
-        validData.trackedInvoices.invoices.map(async (invoice) => {
-          if (!invoice.invoiceUrl) return null
-          const hashIndex = invoice.invoiceUrl.indexOf('#')
-          const fragment = hashIndex === -1 ? '' : invoice.invoiceUrl.slice(hashIndex + 1)
-          if (!fragment) return null
-          const contentHash = await computeContentHash(fragment)
-          return { ...invoice, contentHash }
-        }),
-      )
+      const enriched = validData.trackedInvoices.invoices.map((invoice) => {
+        if (!invoice.invoiceUrl) return null
+        const hashIndex = invoice.invoiceUrl.indexOf('#')
+        const fragment = hashIndex === -1 ? '' : invoice.invoiceUrl.slice(hashIndex + 1)
+        if (!fragment) return null
+        const contentHash = computeContentHash(fragment)
+        return { ...invoice, contentHash }
+      })
       for (const invoice of enriched) {
         if (invoice) {
           addInvoice(invoice)

--- a/src/features/data-export/model/import.ts
+++ b/src/features/data-export/model/import.ts
@@ -71,13 +71,19 @@ export const importUserData = async (data: unknown): Promise<ImportResult> => {
     // Import tracked invoices
     if (validData.trackedInvoices?.invoices) {
       const { addInvoice } = useTrackedInvoiceStore.getState()
-      for (const invoice of validData.trackedInvoices.invoices) {
-        if (!invoice.contentHash && invoice.invoiceUrl) {
+      // Always derive contentHash from URL — never trust pre-supplied values
+      const enriched = await Promise.all(
+        validData.trackedInvoices.invoices.map(async (invoice) => {
+          if (!invoice.invoiceUrl) return null
           const hashIndex = invoice.invoiceUrl.indexOf('#')
           const fragment = hashIndex === -1 ? '' : invoice.invoiceUrl.slice(hashIndex + 1)
-          invoice.contentHash = fragment ? await computeContentHash(fragment) : ''
-        }
-        if (invoice.contentHash) {
+          if (!fragment) return null
+          const contentHash = await computeContentHash(fragment)
+          return { ...invoice, contentHash }
+        }),
+      )
+      for (const invoice of enriched) {
+        if (invoice) {
           addInvoice(invoice)
           trackedInvoicesAdded++
         }

--- a/src/features/data-export/model/import.ts
+++ b/src/features/data-export/model/import.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { useCreatorStore } from '@/entities/creator'
 import { useTrackedInvoiceStore } from '@/entities/invoice'
+import { computeContentHash } from '@/features/invoice-codec'
 
 // Validation schema for import data (accepts old exports with history[] for backward compat)
 const importSchema = z.object({
@@ -35,7 +36,7 @@ export interface ImportResult {
  * Imports user data from a JSON object.
  * Merges with existing data to avoid data loss.
  */
-export const importUserData = (data: unknown): ImportResult => {
+export const importUserData = async (data: unknown): Promise<ImportResult> => {
   try {
     // Validate structure
     const validData = importSchema.parse(data)
@@ -71,8 +72,15 @@ export const importUserData = (data: unknown): ImportResult => {
     if (validData.trackedInvoices?.invoices) {
       const { addInvoice } = useTrackedInvoiceStore.getState()
       for (const invoice of validData.trackedInvoices.invoices) {
-        addInvoice(invoice)
-        trackedInvoicesAdded++
+        if (!invoice.contentHash && invoice.invoiceUrl) {
+          const hashIndex = invoice.invoiceUrl.indexOf('#')
+          const fragment = hashIndex === -1 ? '' : invoice.invoiceUrl.slice(hashIndex + 1)
+          invoice.contentHash = fragment ? await computeContentHash(fragment) : ''
+        }
+        if (invoice.contentHash) {
+          addInvoice(invoice)
+          trackedInvoicesAdded++
+        }
       }
     }
 

--- a/src/features/generate-link/lib/__tests__/generate-invoice.test.ts
+++ b/src/features/generate-link/lib/__tests__/generate-invoice.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/features/invoice-codec', () => ({
   }),
   generateSalt: vi.fn(() => new Uint8Array(16)),
   deriveMagicDust: vi.fn(() => 42),
+  computeContentHash: vi.fn((fragment: string) => Promise.resolve(`${fragment}-hash`)),
 }))
 
 // Mock the creator store

--- a/src/features/generate-link/lib/__tests__/generate-invoice.test.ts
+++ b/src/features/generate-link/lib/__tests__/generate-invoice.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/features/invoice-codec', () => ({
   }),
   generateSalt: vi.fn(() => new Uint8Array(16)),
   deriveMagicDust: vi.fn(() => 42),
-  computeContentHash: vi.fn((fragment: string) => Promise.resolve(`${fragment}-hash`)),
+  computeContentHash: vi.fn((fragment: string) => `${fragment}-hash`),
 }))
 
 // Mock the creator store

--- a/src/features/generate-link/lib/generate-invoice.ts
+++ b/src/features/generate-link/lib/generate-invoice.ts
@@ -72,6 +72,7 @@ export function calculateTotalAmount(invoice: PartialInvoice, lineItems: LineIte
 export async function addToHistory(invoice: Invoice, invoiceUrl: string): Promise<void> {
   const hashIndex = invoiceUrl.indexOf('#')
   const fragment = hashIndex === -1 ? '' : invoiceUrl.slice(hashIndex + 1)
+  if (!fragment) return
   const contentHash = await computeContentHash(fragment)
 
   const { addInvoice } = useTrackedInvoiceStore.getState()

--- a/src/features/generate-link/lib/generate-invoice.ts
+++ b/src/features/generate-link/lib/generate-invoice.ts
@@ -15,7 +15,7 @@ import {
 import { useTrackedInvoiceStore } from '@/entities/invoice'
 import { useCreatorStore } from '@/entities/creator'
 import { nowISO } from '@/shared/lib/date-time'
-import { generateInvoiceUrl, generateSalt, deriveMagicDust } from '@/features/invoice-codec'
+import { generateInvoiceUrl, generateSalt, deriveMagicDust, computeContentHash } from '@/features/invoice-codec'
 import {
   calculateTotalsBigInt,
   formatAmount,
@@ -69,9 +69,14 @@ export function calculateTotalAmount(invoice: PartialInvoice, lineItems: LineIte
  * const url = await generateInvoiceUrl(invoice)
  * addToHistory(invoice, url)
  */
-export function addToHistory(invoice: Invoice, invoiceUrl: string): void {
+export async function addToHistory(invoice: Invoice, invoiceUrl: string): Promise<void> {
+  const hashIndex = invoiceUrl.indexOf('#')
+  const fragment = hashIndex === -1 ? '' : invoiceUrl.slice(hashIndex + 1)
+  const contentHash = await computeContentHash(fragment)
+
   const { addInvoice } = useTrackedInvoiceStore.getState()
   addInvoice({
+    contentHash,
     invoiceId: invoice.invoiceId,
     invoiceUrl,
     source: 'created',
@@ -182,7 +187,7 @@ export async function generateAndTrackInvoice(
   }
 
   // Add to history for later retrieval
-  addToHistory(invoice, invoiceUrl)
+  await addToHistory(invoice, invoiceUrl)
 
   return { url: invoiceUrl, invoice }
 }

--- a/src/features/generate-link/lib/generate-invoice.ts
+++ b/src/features/generate-link/lib/generate-invoice.ts
@@ -73,7 +73,7 @@ export async function addToHistory(invoice: Invoice, invoiceUrl: string): Promis
   const hashIndex = invoiceUrl.indexOf('#')
   const fragment = hashIndex === -1 ? '' : invoiceUrl.slice(hashIndex + 1)
   if (!fragment) return
-  const contentHash = await computeContentHash(fragment)
+  const contentHash = computeContentHash(fragment)
 
   const { addInvoice } = useTrackedInvoiceStore.getState()
   addInvoice({

--- a/src/features/invoice-codec/index.ts
+++ b/src/features/invoice-codec/index.ts
@@ -9,6 +9,7 @@ export * from './lib/chain-dict'
 export * from './lib/app-dict'
 export * from './lib/eip712'
 export * from './lib/security'
+export { computeContentHash } from './lib/content-hash'
 
 // Re-export schema type for convenience (via public API)
 export type { Invoice } from '@/entities/invoice'

--- a/src/features/invoice-codec/lib/__tests__/content-hash.test.ts
+++ b/src/features/invoice-codec/lib/__tests__/content-hash.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { computeContentHash } from '../content-hash'
+
+describe('computeContentHash', () => {
+  it('returns 64-char hex string', async () => {
+    const hash = await computeContentHash('H4IgbghgTg9gxgFg')
+    expect(hash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('is deterministic — same input produces same hash', async () => {
+    const a = await computeContentHash('test-fragment-123')
+    const b = await computeContentHash('test-fragment-123')
+    expect(a).toBe(b)
+  })
+
+  it('different inputs produce different hashes', async () => {
+    const a = await computeContentHash('fragment-A')
+    const b = await computeContentHash('fragment-B')
+    expect(a).not.toBe(b)
+  })
+
+  it('handles empty string', async () => {
+    const hash = await computeContentHash('')
+    expect(hash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('handles unicode content', async () => {
+    const hash = await computeContentHash('инвойс-тест-🎉')
+    expect(hash).toMatch(/^[a-f0-9]{64}$/)
+  })
+})

--- a/src/features/invoice-codec/lib/__tests__/content-hash.test.ts
+++ b/src/features/invoice-codec/lib/__tests__/content-hash.test.ts
@@ -2,30 +2,30 @@ import { describe, it, expect } from 'vitest'
 import { computeContentHash } from '../content-hash'
 
 describe('computeContentHash', () => {
-  it('returns 64-char hex string', async () => {
-    const hash = await computeContentHash('H4IgbghgTg9gxgFg')
+  it('returns 64-char hex string', () => {
+    const hash = computeContentHash('H4IgbghgTg9gxgFg')
     expect(hash).toMatch(/^[a-f0-9]{64}$/)
   })
 
-  it('is deterministic — same input produces same hash', async () => {
-    const a = await computeContentHash('test-fragment-123')
-    const b = await computeContentHash('test-fragment-123')
+  it('is deterministic — same input produces same hash', () => {
+    const a = computeContentHash('test-fragment-123')
+    const b = computeContentHash('test-fragment-123')
     expect(a).toBe(b)
   })
 
-  it('different inputs produce different hashes', async () => {
-    const a = await computeContentHash('fragment-A')
-    const b = await computeContentHash('fragment-B')
+  it('different inputs produce different hashes', () => {
+    const a = computeContentHash('fragment-A')
+    const b = computeContentHash('fragment-B')
     expect(a).not.toBe(b)
   })
 
-  it('handles empty string', async () => {
-    const hash = await computeContentHash('')
+  it('handles empty string', () => {
+    const hash = computeContentHash('')
     expect(hash).toMatch(/^[a-f0-9]{64}$/)
   })
 
-  it('handles unicode content', async () => {
-    const hash = await computeContentHash('инвойс-тест-🎉')
+  it('handles unicode content', () => {
+    const hash = computeContentHash('инвойс-тест-🎉')
     expect(hash).toMatch(/^[a-f0-9]{64}$/)
   })
 })

--- a/src/features/invoice-codec/lib/content-hash.ts
+++ b/src/features/invoice-codec/lib/content-hash.ts
@@ -1,3 +1,6 @@
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex } from '@noble/hashes/utils.js'
+
 /**
  * Compute SHA-256 content hash of an encoded invoice fragment.
  * Returns 64 hex chars (32 bytes). Deterministic: same content → same hash.
@@ -11,10 +14,10 @@
  *
  * Lives in codec because it operates on encoded invoice data
  * and will ship with the codec npm package.
+ *
+ * Sync (via @noble/hashes) so it can be used inside zustand persist migrate().
  */
-export async function computeContentHash(fragment: string): Promise<string> {
+export function computeContentHash(fragment: string): string {
   const data = new TextEncoder().encode(fragment)
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
-  const hashArray = new Uint8Array(hashBuffer)
-  return Array.from(hashArray, (b) => b.toString(16).padStart(2, '0')).join('')
+  return bytesToHex(sha256(data))
 }

--- a/src/features/invoice-codec/lib/content-hash.ts
+++ b/src/features/invoice-codec/lib/content-hash.ts
@@ -1,0 +1,20 @@
+/**
+ * Compute SHA-256 content hash of an encoded invoice fragment.
+ * Returns 64 hex chars (32 bytes). Deterministic: same content → same hash.
+ *
+ * Format: bytes32-compatible (ERC-3009 nonce). Add `0x` prefix for on-chain use.
+ *
+ * Used as:
+ * - TrackedInvoice store key (collision-free identity)
+ * - ERC-3009 `transferWithAuthorization` nonce for x402 payment matching (v1.3)
+ *   Given invoice → contentHash → search on-chain for tx with nonce → payment found
+ *
+ * Lives in codec because it operates on encoded invoice data
+ * and will ship with the codec npm package.
+ */
+export async function computeContentHash(fragment: string): Promise<string> {
+  const data = new TextEncoder().encode(fragment)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+  const hashArray = new Uint8Array(hashBuffer)
+  return Array.from(hashArray, (b) => b.toString(16).padStart(2, '0')).join('')
+}

--- a/src/features/invoice-codec/lib/parse-hash.d.ts
+++ b/src/features/invoice-codec/lib/parse-hash.d.ts
@@ -6,6 +6,7 @@ import type { Invoice } from '@/entities/invoice';
 export type HashParseResult = {
     success: true;
     data: Invoice;
+    contentHash: string;
 } | {
     success: false;
     error: Error;

--- a/src/features/invoice-codec/lib/parse-hash.ts
+++ b/src/features/invoice-codec/lib/parse-hash.ts
@@ -1,12 +1,15 @@
 import type { Invoice } from '@/entities/invoice'
 
+import { computeContentHash } from './content-hash'
 import { decodeInvoice } from './decode'
 
 /**
  * Result type for hash parsing operation.
  * Uses discriminated union for type-safe error handling.
  */
-export type HashParseResult = { success: true; data: Invoice } | { success: false; error: Error }
+export type HashParseResult =
+  | { success: true; data: Invoice; contentHash: string }
+  | { success: false; error: Error }
 
 /**
  * Parses URL hash fragment into Invoice data.
@@ -38,7 +41,8 @@ export async function parseInvoiceHash(hash: string): Promise<HashParseResult> {
 
   try {
     const data = await decodeInvoice(hash)
-    return { success: true, data }
+    const contentHash = await computeContentHash(hash)
+    return { success: true, data, contentHash }
   } catch (error) {
     return {
       success: false,

--- a/src/features/invoice-codec/lib/parse-hash.ts
+++ b/src/features/invoice-codec/lib/parse-hash.ts
@@ -40,10 +40,8 @@ export async function parseInvoiceHash(hash: string): Promise<HashParseResult> {
   }
 
   try {
-    const [data, contentHash] = await Promise.all([
-      decodeInvoice(hash),
-      computeContentHash(hash),
-    ])
+    const contentHash = computeContentHash(hash)
+    const data = await decodeInvoice(hash)
     return { success: true, data, contentHash }
   } catch (error) {
     return {

--- a/src/features/invoice-codec/lib/parse-hash.ts
+++ b/src/features/invoice-codec/lib/parse-hash.ts
@@ -40,8 +40,10 @@ export async function parseInvoiceHash(hash: string): Promise<HashParseResult> {
   }
 
   try {
-    const data = await decodeInvoice(hash)
-    const contentHash = await computeContentHash(hash)
+    const [data, contentHash] = await Promise.all([
+      decodeInvoice(hash),
+      computeContentHash(hash),
+    ])
     return { success: true, data, contentHash }
   } catch (error) {
     return {

--- a/src/features/invoice-history/__tests__/HistoryList.test.tsx
+++ b/src/features/invoice-history/__tests__/HistoryList.test.tsx
@@ -45,6 +45,7 @@ function makeEntry(overrides: {
   dueAt?: number
 } = {}): DecodedHistoryEntry {
   const tracked: TrackedInvoice = {
+    contentHash: `${overrides.invoiceId ?? 'INV-042'}-hash`,
     invoiceId: overrides.invoiceId ?? 'INV-042',
     invoiceUrl: 'https://voidpay.xyz/pay#test',
     source: 'created',

--- a/src/features/invoice-history/ui/InvoiceCard.tsx
+++ b/src/features/invoice-history/ui/InvoiceCard.tsx
@@ -136,8 +136,8 @@ export function InvoiceCard({
       </div>
 
       {debug && debugOpen && (
-        <pre className="mt-3 max-h-48 overflow-auto rounded-lg bg-zinc-950/80 p-3 text-xs text-zinc-500">
-          {JSON.stringify({ tracked, decodeSuccess: invoice !== null }, null, 2)}
+        <pre className="mt-3 max-h-64 overflow-auto rounded-lg bg-zinc-950/80 p-3 text-xs text-zinc-500">
+          {JSON.stringify({ tracked, invoice, status }, null, 2)}
         </pre>
       )}
     </InvoiceCardShell>

--- a/src/features/payment/model/__tests__/use-batch-check.test.ts
+++ b/src/features/payment/model/__tests__/use-batch-check.test.ts
@@ -29,6 +29,7 @@ vi.mock('@/entities/network', () => ({
 // ---------------------------------------------------------------------------
 const mockSetTxHash = vi.fn()
 let mockInvoices: Array<{
+  contentHash: string
   invoiceId: string
   source: 'created' | 'received'
   txHash?: string
@@ -79,10 +80,12 @@ function makeInvoice(
   source: 'created' | 'received' = 'created',
   txHash?: string,
 ) {
+  const hash = `${id}-hash`
   return {
+    contentHash: hash,
     invoiceId: id,
     source,
-    invoiceUrl: `https://voidpay.xyz/pay#${id}`,
+    invoiceUrl: `https://voidpay.xyz/pay#${hash}`,
     createdAt: new Date().toISOString(),
     ...(txHash ? { txHash } : {}),
   }
@@ -272,7 +275,7 @@ describe('useBatchCheck', () => {
     await waitFor(() => {
       expect(mockSetTxHash).toHaveBeenCalledTimes(1)
       expect(mockSetTxHash).toHaveBeenCalledWith(
-        'INV-MATCH-002',
+        'INV-MATCH-002-hash',
         secondTransfer.hash,
         false,
       )

--- a/src/features/payment/model/__tests__/use-finalization-tracker.test.ts
+++ b/src/features/payment/model/__tests__/use-finalization-tracker.test.ts
@@ -27,7 +27,7 @@ const { mockSetValidated, mockSetFinalized, mockResetPaymentState } = vi.hoisted
 
 vi.mock('@/entities/invoice', () => {
   const storeState = {
-    invoices: [] as Array<{ invoiceId: string; finalized?: boolean }>,
+    invoices: [] as Array<{ contentHash: string; invoiceId: string; finalized?: boolean }>,
     setValidated: mockSetValidated,
     setFinalized: mockSetFinalized,
     resetPaymentState: mockResetPaymentState,
@@ -87,14 +87,14 @@ describe('useFinalizationTracker', () => {
 
     renderHook(() =>
       useFinalizationTracker({
-        invoiceId: 'INV-001',
+        contentHash: 'inv001-hash',
         txHash: MOCK_TX_HASH,
         networkId: 1, // Ethereum — 60 min timeout
       })
     )
 
     await waitFor(() => {
-      expect(mockSetFinalized).toHaveBeenCalledWith('INV-001')
+      expect(mockSetFinalized).toHaveBeenCalledWith('inv001-hash')
     })
 
     // Silent — no toast on success
@@ -112,7 +112,7 @@ describe('useFinalizationTracker', () => {
 
     renderHook(() =>
       useFinalizationTracker({
-        invoiceId: 'INV-001',
+        contentHash: 'inv001-hash',
         txHash: MOCK_TX_HASH,
         networkId: 1, // Ethereum — 60 min timeout
       })
@@ -135,7 +135,7 @@ describe('useFinalizationTracker', () => {
 
     renderHook(() =>
       useFinalizationTracker({
-        invoiceId: 'INV-L2-001',
+        contentHash: 'inv-l2-001-hash',
         txHash: MOCK_TX_HASH,
         networkId: 42161, // Arbitrum — 30 min timeout
       })
@@ -159,7 +159,7 @@ describe('useFinalizationTracker', () => {
 
     renderHook(() =>
       useFinalizationTracker({
-        invoiceId: 'INV-001',
+        contentHash: 'inv001-hash',
         txHash: MOCK_TX_HASH,
         networkId: 1,
         enabled: false,
@@ -185,7 +185,7 @@ describe('useFinalizationTracker', () => {
     const { rerender } = renderHook(
       ({ enabled }: { enabled: boolean }) =>
         useFinalizationTracker({
-          invoiceId: 'INV-001',
+          contentHash: 'inv001-hash',
           txHash: MOCK_TX_HASH,
           networkId: 1,
           enabled,
@@ -200,7 +200,7 @@ describe('useFinalizationTracker', () => {
     rerender({ enabled: true })
 
     await waitFor(() => {
-      expect(mockSetFinalized).toHaveBeenCalledWith('INV-001')
+      expect(mockSetFinalized).toHaveBeenCalledWith('inv001-hash')
     })
   })
 
@@ -213,14 +213,14 @@ describe('useFinalizationTracker', () => {
 
     renderHook(() =>
       useFinalizationTracker({
-        invoiceId: 'INV-REORG-001',
+        contentHash: 'inv-reorg-001-hash',
         txHash: MOCK_TX_HASH,
         networkId: 1,
       })
     )
 
     await waitFor(() => {
-      expect(mockResetPaymentState).toHaveBeenCalledWith('INV-REORG-001')
+      expect(mockResetPaymentState).toHaveBeenCalledWith('inv-reorg-001-hash')
     })
 
     // Must alert user about reorg via toast

--- a/src/features/payment/model/__tests__/use-manual-verify.test.ts
+++ b/src/features/payment/model/__tests__/use-manual-verify.test.ts
@@ -35,7 +35,7 @@ const mockSetTxHash = vi.fn()
 const mockSetValidated = vi.fn()
 const mockSetError = vi.fn()
 const mockGetInvoice = vi.fn()
-const mockInvoices: Array<{ invoiceId: string; txHash?: string }> = []
+const mockInvoices: Array<{ contentHash: string; invoiceId: string; txHash?: string }> = []
 
 vi.mock('@/entities/invoice', () => {
   const getStore = () => ({
@@ -71,7 +71,7 @@ const EXACT_TOTAL = 1_000_000_000_000_000_000n // 1 ETH in wei
 const NETWORK_ID = 1
 
 const BASE_PARAMS = {
-  invoiceId: 'INV-MANUAL-001',
+  contentHash: 'manual-001-hash',
   networkId: NETWORK_ID,
   recipient: RECIPIENT,
   exactTotal: EXACT_TOTAL,
@@ -154,7 +154,7 @@ describe('useManualVerify', () => {
   // -------------------------------------------------------------------------
   it('rejects txHash already linked to a different invoice in the store', async () => {
     // Another invoice already has this txHash
-    mockInvoices.push({ invoiceId: 'INV-OTHER-999', txHash: VALID_TX_HASH })
+    mockInvoices.push({ contentHash: 'other-999-hash', invoiceId: 'INV-OTHER-999', txHash: VALID_TX_HASH })
 
     const { result } = renderHook(() => useManualVerify(BASE_PARAMS))
 
@@ -225,7 +225,7 @@ describe('useManualVerify', () => {
     expect(result.current.result?.actualAmount).toBe(EXACT_TOTAL)
     expect(result.current.result?.expectedAmount).toBe(EXACT_TOTAL)
     expect(mockSetTxHash).toHaveBeenCalledWith(
-      'INV-MANUAL-001',
+      'manual-001-hash',
       VALID_TX_HASH,
       false, // soft-verified; verification hook takes over
     )
@@ -343,6 +343,6 @@ describe('useManualVerify', () => {
     expect(mockVerifyNativeReceipt).not.toHaveBeenCalled()
 
     expect(result.current.result?.verified).toBe(true)
-    expect(mockSetTxHash).toHaveBeenCalledWith('INV-MANUAL-001', VALID_TX_HASH, false)
+    expect(mockSetTxHash).toHaveBeenCalledWith('manual-001-hash', VALID_TX_HASH, false)
   })
 })

--- a/src/features/payment/model/__tests__/use-payment-flow.test.ts
+++ b/src/features/payment/model/__tests__/use-payment-flow.test.ts
@@ -129,14 +129,14 @@ describe('usePaymentFlow', () => {
 
   it('returns initial idle state', () => {
     const { result } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
     expect(result.current.step).toBe('idle')
   })
 
   it('handlePay dispatches START(sending) for native token on correct network', () => {
     const { result } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
 
     act(() => {
@@ -149,7 +149,7 @@ describe('usePaymentFlow', () => {
 
   it('calls sendTransaction for native token when step is sending', () => {
     const { result } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
 
     act(() => {
@@ -169,7 +169,7 @@ describe('usePaymentFlow', () => {
     } as Invoice
 
     const { result } = renderHook(() =>
-      usePaymentFlow({ invoice: erc20Invoice, invoiceId: 'INV-001', exactTotal: '1000000' })
+      usePaymentFlow({ invoice: erc20Invoice, contentHash: 'inv001hash', exactTotal: '1000000' })
     )
 
     act(() => {
@@ -181,7 +181,7 @@ describe('usePaymentFlow', () => {
 
   it('provides idleSubState derived from wallet context', () => {
     const { result } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
     expect(result.current.idleSubState).toBe('ready')
   })
@@ -190,7 +190,7 @@ describe('usePaymentFlow', () => {
   it('dispatches START(connecting) when disconnected', () => {
     mockIsConnected = false
     const { result } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
 
     expect(result.current.idleSubState).toBe('disconnected')
@@ -219,7 +219,7 @@ describe('usePaymentFlow', () => {
     })
 
     const { result } = renderHook(() =>
-      usePaymentFlow({ invoice: { ...mockInvoice, networkId: 137 }, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: { ...mockInvoice, networkId: 137 }, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
 
     expect(result.current.idleSubState).toBe('wrong-network')
@@ -248,7 +248,7 @@ describe('usePaymentFlow', () => {
     })
 
     const { result, rerender } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
 
     // Start payment
@@ -285,7 +285,7 @@ describe('usePaymentFlow', () => {
     })
 
     const { result, rerender } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
 
     act(() => {
@@ -296,7 +296,7 @@ describe('usePaymentFlow', () => {
     rerender()
 
     expect(mockSetError).toHaveBeenCalledWith(
-      'INV-001',
+      'inv001hash',
       'Unexpected error: Something went wrong. Please try again.',
     )
   })
@@ -315,7 +315,7 @@ describe('usePaymentFlow', () => {
     })
 
     const { result, rerender } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
 
     act(() => {
@@ -344,7 +344,7 @@ describe('usePaymentFlow', () => {
     })
 
     const { result, rerender } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
 
     // Trigger initial payment
@@ -385,7 +385,7 @@ describe('usePaymentFlow', () => {
     })
 
     const { result, rerender } = renderHook(() =>
-      usePaymentFlow({ invoice: mockInvoice, invoiceId: 'INV-001', exactTotal: '1000000000000000000' })
+      usePaymentFlow({ invoice: mockInvoice, contentHash: 'inv001hash', exactTotal: '1000000000000000000' })
     )
 
     // Start payment and get to sending state

--- a/src/features/payment/model/__tests__/use-payment-polling.test.ts
+++ b/src/features/payment/model/__tests__/use-payment-polling.test.ts
@@ -67,7 +67,7 @@ import type { TransferResult } from '../../lib/match-transfer'
 // Test fixtures
 // ---------------------------------------------------------------------------
 const BASE_PARAMS = {
-  invoiceId: 'INV-POLL-001',
+  contentHash: 'poll-001-hash',
   toAddress: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as const,
   chainId: 1,
   category: 'external' as const,
@@ -77,7 +77,7 @@ const BASE_PARAMS = {
 
 const ERC20_PARAMS = {
   ...BASE_PARAMS,
-  invoiceId: 'INV-POLL-ERC20',
+  contentHash: 'poll-erc20-hash',
   category: 'erc20' as const,
   contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
   exactTotal: 1_000_000n,
@@ -484,9 +484,9 @@ describe('usePaymentPolling', () => {
   // -------------------------------------------------------------------------
   it('session limit: rejects starting a new mode when 3 sessions are already active', async () => {
     // Render 3 hooks all in aggressive mode
-    const hook1 = renderHook(() => usePaymentPolling({ ...BASE_PARAMS, invoiceId: 'INV-001' }))
-    const hook2 = renderHook(() => usePaymentPolling({ ...BASE_PARAMS, invoiceId: 'INV-002' }))
-    const hook3 = renderHook(() => usePaymentPolling({ ...BASE_PARAMS, invoiceId: 'INV-003' }))
+    const hook1 = renderHook(() => usePaymentPolling({ ...BASE_PARAMS, contentHash: 'session-hash-1' }))
+    const hook2 = renderHook(() => usePaymentPolling({ ...BASE_PARAMS, contentHash: 'session-hash-2' }))
+    const hook3 = renderHook(() => usePaymentPolling({ ...BASE_PARAMS, contentHash: 'session-hash-3' }))
 
     await waitFor(() => expect(hook1.result.current.isLoading).toBe(false))
     await waitFor(() => expect(hook2.result.current.isLoading).toBe(false))
@@ -501,7 +501,7 @@ describe('usePaymentPolling', () => {
     expect(hook3.result.current.mode).toBe('aggressive')
 
     // 4th hook tries to start aggressive — should be rejected
-    const hook4 = renderHook(() => usePaymentPolling({ ...BASE_PARAMS, invoiceId: 'INV-004' }))
+    const hook4 = renderHook(() => usePaymentPolling({ ...BASE_PARAMS, contentHash: 'session-hash-4' }))
     await waitFor(() => expect(hook4.result.current.isLoading).toBe(false))
 
     act(() => { hook4.result.current.startAggressivePolling() })
@@ -532,7 +532,7 @@ describe('usePaymentPolling', () => {
 
     await waitFor(() => {
       expect(mockSetTxHash).toHaveBeenCalledWith(
-        BASE_PARAMS.invoiceId,
+        BASE_PARAMS.contentHash,
         MOCK_TRANSFER.hash,
         false, // not yet validated
       )
@@ -580,7 +580,7 @@ describe('usePaymentPolling', () => {
 
     await waitFor(() => {
       expect(mockSetTxHash).toHaveBeenCalledWith(
-        ERC20_PARAMS.invoiceId,
+        ERC20_PARAMS.contentHash,
         erc20Transfer.hash,
         false,
       )

--- a/src/features/payment/model/__tests__/use-payment-verification.test.ts
+++ b/src/features/payment/model/__tests__/use-payment-verification.test.ts
@@ -117,14 +117,14 @@ describe('usePaymentVerification', () => {
     const { result } = renderHook(() =>
       usePaymentVerification({
         invoice: mockNativeInvoice,
-        invoiceId: 'INV-NATIVE-001',
+        contentHash: 'native-001-hash',
         txHash: MOCK_TX_HASH,
         exactTotal: '1000000000000000000',
       })
     )
 
     await waitFor(() => {
-      expect(mockSetValidated).toHaveBeenCalledWith('INV-NATIVE-001', true)
+      expect(mockSetValidated).toHaveBeenCalledWith('native-001-hash', true)
     })
 
     expect(mockSetError).not.toHaveBeenCalled()
@@ -156,14 +156,14 @@ describe('usePaymentVerification', () => {
     const { result } = renderHook(() =>
       usePaymentVerification({
         invoice: mockErc20Invoice,
-        invoiceId: 'INV-ERC20-001',
+        contentHash: 'erc20-001-hash',
         txHash: MOCK_TX_HASH,
         exactTotal: '1000000',
       })
     )
 
     await waitFor(() => {
-      expect(mockSetValidated).toHaveBeenCalledWith('INV-ERC20-001', true)
+      expect(mockSetValidated).toHaveBeenCalledWith('erc20-001-hash', true)
     })
 
     expect(mockSetError).not.toHaveBeenCalled()
@@ -188,7 +188,7 @@ describe('usePaymentVerification', () => {
     renderHook(() =>
       usePaymentVerification({
         invoice: mockNativeInvoice,
-        invoiceId: 'INV-NATIVE-001',
+        contentHash: 'native-001-hash',
         txHash: MOCK_TX_HASH,
         exactTotal: '1000000000000000000',
       })
@@ -196,7 +196,7 @@ describe('usePaymentVerification', () => {
 
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith(
-        'INV-NATIVE-001',
+        'native-001-hash',
         expect.stringContaining("amount doesn't match"),
       )
     })
@@ -220,7 +220,7 @@ describe('usePaymentVerification', () => {
     const { result } = renderHook(() =>
       usePaymentVerification({
         invoice: mockNativeInvoice,
-        invoiceId: 'INV-NATIVE-001',
+        contentHash: 'native-001-hash',
         txHash: MOCK_TX_HASH,
         exactTotal: '1000000000000000000',
       })
@@ -249,7 +249,7 @@ describe('usePaymentVerification', () => {
     const { result, rerender } = renderHook(() =>
       usePaymentVerification({
         invoice: mockNativeInvoice,
-        invoiceId: 'INV-NATIVE-001',
+        contentHash: 'native-001-hash',
         txHash: MOCK_TX_HASH,
         exactTotal: '1000000000000000000',
       })
@@ -266,7 +266,7 @@ describe('usePaymentVerification', () => {
     rerender()
 
     await waitFor(() => {
-      expect(mockSetValidated).toHaveBeenCalledWith('INV-NATIVE-001', true)
+      expect(mockSetValidated).toHaveBeenCalledWith('native-001-hash', true)
     })
   })
 
@@ -284,7 +284,7 @@ describe('usePaymentVerification', () => {
     const { result } = renderHook(() =>
       usePaymentVerification({
         invoice: mockNativeInvoice,
-        invoiceId: 'INV-NATIVE-001',
+        contentHash: 'native-001-hash',
         txHash: MOCK_TX_HASH,
         exactTotal: '1000000000000000000',
         enabled: false,
@@ -317,7 +317,7 @@ describe('usePaymentVerification', () => {
       ({ enabled }: { enabled: boolean }) =>
         usePaymentVerification({
           invoice: mockNativeInvoice,
-          invoiceId: 'INV-NATIVE-001',
+          contentHash: 'native-001-hash',
           txHash: MOCK_TX_HASH,
           exactTotal: '1000000000000000000',
           enabled,
@@ -332,7 +332,7 @@ describe('usePaymentVerification', () => {
     rerender({ enabled: true })
 
     await waitFor(() => {
-      expect(mockSetValidated).toHaveBeenCalledWith('INV-NATIVE-001', true)
+      expect(mockSetValidated).toHaveBeenCalledWith('native-001-hash', true)
     })
   })
 
@@ -354,7 +354,7 @@ describe('usePaymentVerification', () => {
     const { result, rerender } = renderHook(() =>
       usePaymentVerification({
         invoice: mockNativeInvoice,
-        invoiceId: 'INV-NATIVE-001',
+        contentHash: 'native-001-hash',
         txHash: MOCK_TX_HASH,
         exactTotal: '1000000000000000000',
       })
@@ -375,7 +375,7 @@ describe('usePaymentVerification', () => {
     rerender()
 
     await waitFor(() => {
-      expect(mockSetValidated).toHaveBeenCalledWith('INV-NATIVE-001', true)
+      expect(mockSetValidated).toHaveBeenCalledWith('native-001-hash', true)
     })
   })
 })

--- a/src/features/payment/model/polling/loops.ts
+++ b/src/features/payment/model/polling/loops.ts
@@ -27,8 +27,8 @@ export function assignAggressiveLoop(
   loopRef: MutableRefObject<() => void>,
   refs: LoopRefs,
   doFetch: () => Promise<TransferResult | null>,
-  setTxHash: (invoiceId: string, hash: `0x${string}`, validated: boolean) => void,
-  invoiceId: string,
+  setTxHash: (contentHash: string, hash: `0x${string}`, validated: boolean) => void,
+  contentHash: string,
   flushStop: (isError?: boolean, errorMsg?: string) => void,
 ): void {
   loopRef.current = () => {
@@ -58,7 +58,7 @@ export function assignAggressiveLoop(
       if (!refs.isActiveRef.current || refs.sessionModeRef.current !== 'aggressive') return
 
       if (matched) {
-        setTxHash(invoiceId, matched.hash, false)
+        setTxHash(contentHash, matched.hash, false)
         flushStop()
         return
       }
@@ -77,8 +77,8 @@ export function assignWatchingLoop(
   watchStepRef: MutableRefObject<number>,
   refs: LoopRefs,
   doFetch: () => Promise<TransferResult | null>,
-  setTxHash: (invoiceId: string, hash: `0x${string}`, validated: boolean) => void,
-  invoiceId: string,
+  setTxHash: (contentHash: string, hash: `0x${string}`, validated: boolean) => void,
+  contentHash: string,
   flushStop: (isError?: boolean, errorMsg?: string) => void,
 ): void {
   loopRef.current = () => {
@@ -111,7 +111,7 @@ export function assignWatchingLoop(
       if (!refs.isActiveRef.current || refs.sessionModeRef.current !== 'watching') return
 
       if (matched) {
-        setTxHash(invoiceId, matched.hash, false)
+        setTxHash(contentHash, matched.hash, false)
         flushStop()
         return
       }

--- a/src/features/payment/model/polling/visibility-handler.ts
+++ b/src/features/payment/model/polling/visibility-handler.ts
@@ -17,14 +17,14 @@ export interface VisibilityHandlerRefs {
 
 export interface VisibilityHandlerCallbacks {
   doFetch: () => Promise<TransferResult | null>
-  setTxHash: (invoiceId: string, hash: `0x${string}`, validated: boolean) => void
+  setTxHash: (contentHash: string, hash: `0x${string}`, validated: boolean) => void
   flushStop: (isError?: boolean, errorMsg?: string) => void
   aggressiveLoopRef: MutableRefObject<() => void>
   watchingLoopRef: MutableRefObject<() => void>
 }
 
 export function setupVisibilityHandler(
-  invoiceId: string,
+  contentHash: string,
   refs: VisibilityHandlerRefs,
   callbacks: VisibilityHandlerCallbacks,
 ): void {
@@ -58,7 +58,7 @@ export function setupVisibilityHandler(
       const matched = await callbacks.doFetch()
       if (!refs.isActiveRef.current) return
       if (matched) {
-        callbacks.setTxHash(invoiceId, matched.hash, false)
+        callbacks.setTxHash(contentHash, matched.hash, false)
         callbacks.flushStop()
         return
       }

--- a/src/features/payment/model/types.ts
+++ b/src/features/payment/model/types.ts
@@ -104,8 +104,8 @@ export function parseDevOverride(dev: DevPaymentVisualStep): { step: PaymentStep
 export interface SmartPayButtonProps {
   /** Decoded invoice data */
   invoice: Invoice
-  /** Invoice ID for store persistence */
-  invoiceId: string
+  /** Content hash for store persistence */
+  contentHash: string
   /** Exact total in atomic units (from computeAmounts — computed by parent) */
   exactTotal: string
   /** Clean subtotal in atomic units (without Magic Dust) for button label display */

--- a/src/features/payment/model/use-batch-check.ts
+++ b/src/features/payment/model/use-batch-check.ts
@@ -137,7 +137,7 @@ export function useBatchCheck({ decodeInvoiceUrl }: UseBatchCheckParams): UseBat
             const data = (await response.json()) as { transfers: TransferResult[] }
             const match = matchTransfer(data.transfers, exactTotal, tokenAddress)
             if (match) {
-              setTxHash(invoice.invoiceId, match.hash, false)
+              setTxHash(invoice.contentHash, match.hash, false)
             }
           }
         } catch {

--- a/src/features/payment/model/use-finalization-tracker.ts
+++ b/src/features/payment/model/use-finalization-tracker.ts
@@ -5,7 +5,7 @@ import { toast } from '@/shared/lib/toast'
 import { getFinalizationTimeout } from '@/entities/network'
 
 export interface UseFinalizationTrackerParams {
-  invoiceId: string
+  contentHash: string
   txHash: `0x${string}`
   networkId: number
   onReorgDetected?: (() => void) | undefined
@@ -15,7 +15,7 @@ export interface UseFinalizationTrackerParams {
 type TrackingState = 'idle' | 'tracking' | 'finalized' | 'reorg' | 'timeout'
 
 export function useFinalizationTracker({
-  invoiceId,
+  contentHash,
   txHash,
   networkId,
   onReorgDetected,
@@ -31,10 +31,10 @@ export function useFinalizationTracker({
   useEffect(() => {
     if (!enabled) return
     const tracked = useTrackedInvoiceStore.getState().invoices.find(
-      (inv) => inv.invoiceId === invoiceId,
+      (inv) => inv.contentHash === contentHash,
     )
     if (tracked?.finalized) return
-    if (!publicClient || !txHash || !invoiceId) return
+    if (!publicClient || !txHash || !contentHash) return
 
     const timeoutMs = getFinalizationTimeout(networkId)
     let cancelled = false
@@ -54,8 +54,8 @@ export function useFinalizationTracker({
       .then(() => {
         if (cancelled) return
         clearTimeout(timeoutId)
-        setValidated(invoiceId, true)
-        setFinalized(invoiceId)
+        setValidated(contentHash, true)
+        setFinalized(contentHash)
         setTrackingState('finalized')
       })
       .catch((_err) => {
@@ -63,7 +63,7 @@ export function useFinalizationTracker({
         clearTimeout(timeoutId)
         // Reorg: transaction disappeared from chain
         toast.error('Chain reorg detected — transaction not found on chain')
-        resetPaymentState(invoiceId)
+        resetPaymentState(contentHash)
         onReorgDetected?.()
         setTrackingState('reorg')
       })
@@ -72,5 +72,5 @@ export function useFinalizationTracker({
       cancelled = true
       clearTimeout(timeoutId)
     }
-  }, [enabled, invoiceId, txHash, networkId, publicClient, setFinalized, setValidated, resetPaymentState, onReorgDetected])
+  }, [enabled, contentHash, txHash, networkId, publicClient, setFinalized, setValidated, resetPaymentState, onReorgDetected])
 }

--- a/src/features/payment/model/use-manual-verify.ts
+++ b/src/features/payment/model/use-manual-verify.ts
@@ -6,7 +6,7 @@ import { useTrackedInvoiceStore } from '@/entities/invoice'
 import { verifyNativeReceipt, verifyErc20Receipt } from '../lib/verify-receipt'
 
 export interface UseManualVerifyParams {
-  invoiceId: string
+  contentHash: string
   networkId: number
   recipient: string
   exactTotal: bigint
@@ -31,7 +31,7 @@ export interface UseManualVerifyResult {
 const TX_HASH_REGEX = /^0x[a-fA-F0-9]{64}$/
 
 export function useManualVerify({
-  invoiceId,
+  contentHash,
   networkId,
   recipient,
   exactTotal,
@@ -59,7 +59,7 @@ export function useManualVerify({
 
     // W3-006: uniqueness check — reject if linked to a different invoice
     const alreadyLinked = useTrackedInvoiceStore.getState().invoices.some(
-      (inv) => inv.txHash === txHash && inv.invoiceId !== invoiceId,
+      (inv) => inv.txHash === txHash && inv.contentHash !== contentHash,
     )
     if (alreadyLinked) {
       setError('Transaction hash is already linked to another invoice')
@@ -116,14 +116,14 @@ export function useManualVerify({
       setResult(finalResult)
 
       if (verifyResult.verified) {
-        setTxHash(invoiceId, hash, false)
+        setTxHash(contentHash, hash, false)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Verification failed')
     } finally {
       setIsLoading(false)
     }
-  }, [invoiceId, recipient, exactTotal, tokenAddress, publicClient, setTxHash, decimals, tokenSymbol])
+  }, [contentHash, recipient, exactTotal, tokenAddress, publicClient, setTxHash, decimals, tokenSymbol])
 
   const ret: UseManualVerifyResult = { verify, isLoading }
   if (result !== undefined) ret.result = result

--- a/src/features/payment/model/use-payment-flow.ts
+++ b/src/features/payment/model/use-payment-flow.ts
@@ -79,7 +79,7 @@ export function paymentReducer(state: PaymentState, action: PaymentAction): Paym
 
 interface UsePaymentFlowParams {
   invoice: Invoice
-  invoiceId: string
+  contentHash: string
   exactTotal: string
 }
 
@@ -110,7 +110,7 @@ function createPaymentError(
  */
 export function usePaymentFlow({
   invoice,
-  invoiceId,
+  contentHash,
   exactTotal,
 }: UsePaymentFlowParams): UsePaymentFlowReturn {
   const [state, dispatch] = useReducer(paymentReducer, INITIAL_PAYMENT_STATE)
@@ -280,9 +280,9 @@ export function usePaymentFlow({
       return
     }
 
-    setTxHash(invoiceId, txHash, false)
+    setTxHash(contentHash, txHash, false)
     dispatch({ type: 'CONFIRMED' })
-  }, [state.step, isReceiptSuccess, txHash, receipt, invoiceId, setTxHash])
+  }, [state.step, isReceiptSuccess, txHash, receipt, contentHash, setTxHash])
 
   // Effect: Handle wagmi errors (sticky — cleared by resetSend/resetWrite in handlePay)
   useEffect(() => {
@@ -305,9 +305,9 @@ export function usePaymentFlow({
     track(AnalyticsEvent.ERROR_PAYMENT, { error_type: errorType })
 
     const error = createPaymentError(errorType, state.step)
-    setError(invoiceId, error.message)
+    setError(contentHash, error.message)
     dispatch({ type: 'ERROR', error })
-  }, [sendError, writeError, receiptError, switchError, state.step, invoiceId, setError])
+  }, [sendError, writeError, receiptError, switchError, state.step, contentHash, setError])
 
   return { step: state.step, error: state.error, txHash: state.txHash, handlePay, handleCancel, idleSubState }
 }

--- a/src/features/payment/model/use-payment-polling.ts
+++ b/src/features/payment/model/use-payment-polling.ts
@@ -27,7 +27,7 @@ export type { PollingMode, PollingState }
 
 export interface UsePaymentPollingParams {
   enabled?: boolean  // default true for backward compatibility
-  invoiceId: string
+  contentHash: string
   toAddress: string
   chainId: number
   contractAddress?: string
@@ -53,7 +53,7 @@ export interface UsePaymentPollingResult {
 // ---------------------------------------------------------------------------
 
 export function usePaymentPolling(params: UsePaymentPollingParams): UsePaymentPollingResult {
-  const { enabled = true, invoiceId, toAddress, chainId, contractAddress, category, exactTotal, fromBlock } = params
+  const { enabled = true, contentHash, toAddress, chainId, contractAddress, category, exactTotal, fromBlock } = params
 
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
 
@@ -108,17 +108,17 @@ export function usePaymentPolling(params: UsePaymentPollingParams): UsePaymentPo
 
   // ---- Loop assignments (updated every render via .current) ----
   const loopRefs = { isActiveRef, sessionModeRef, sessionStartedAtRef, timerRef }
-  assignAggressiveLoop(aggressiveLoopRef, loopRefs, doFetch, setTxHash, invoiceId, flushStop)
-  assignWatchingLoop(watchingLoopRef, watchStepRef, loopRefs, doFetch, setTxHash, invoiceId, flushStop)
+  assignAggressiveLoop(aggressiveLoopRef, loopRefs, doFetch, setTxHash, contentHash, flushStop)
+  assignWatchingLoop(watchingLoopRef, watchStepRef, loopRefs, doFetch, setTxHash, contentHash, flushStop)
 
   // ---- Visibility handler ----
   const handleVisibilitySetup = useCallback(() => {
-    setupVisibilityHandler(invoiceId, {
+    setupVisibilityHandler(contentHash, {
       isActiveRef, sessionModeRef, sessionStartedAtRef, timerRef, visHandlerRef,
     }, {
       doFetch, setTxHash, flushStop, aggressiveLoopRef, watchingLoopRef,
     })
-  }, [doFetch, invoiceId, setTxHash, flushStop])
+  }, [doFetch, contentHash, setTxHash, flushStop])
 
   // ---- Public actions ----
   const startAutoCheck = useCallback(() => {
@@ -179,7 +179,7 @@ export function usePaymentPolling(params: UsePaymentPollingParams): UsePaymentPo
       void (async () => {
         const matched = await doFetch()
         if (!isActiveRef.current || sessionModeRef.current !== 'auto-check') return
-        if (matched) setTxHash(invoiceId, matched.hash, false)
+        if (matched) setTxHash(contentHash, matched.hash, false)
         isActiveRef.current = false
         sessionModeRef.current = 'idle'
         flushSync(() => dispatch({ type: 'STOP' }))
@@ -193,7 +193,7 @@ export function usePaymentPolling(params: UsePaymentPollingParams): UsePaymentPo
         if (!isActiveRef.current || sessionModeRef.current !== 'manual') return
 
         if (matched) {
-          setTxHash(invoiceId, matched.hash, false)
+          setTxHash(contentHash, matched.hash, false)
           isActiveRef.current = false
           sessionModeRef.current = 'idle'
           flushSync(() => dispatch({ type: 'STOP' }))
@@ -234,7 +234,7 @@ export function usePaymentPolling(params: UsePaymentPollingParams): UsePaymentPo
 
     const check = () => {
       const tracked = useTrackedInvoiceStore.getState().invoices.find(
-        (inv) => inv.invoiceId === invoiceId,
+        (inv) => inv.contentHash === contentHash,
       )
       if (tracked?.txHash || tracked?.finalized) return
       startAutoCheck()

--- a/src/features/payment/model/use-payment-verification.ts
+++ b/src/features/payment/model/use-payment-verification.ts
@@ -9,7 +9,7 @@ import type { ConfirmationProgress } from '@/shared/lib/invoice-types'
 
 export interface UsePaymentVerificationParams {
   invoice: Invoice
-  invoiceId: string
+  contentHash: string
   txHash: `0x${string}`
   exactTotal: string
   enabled?: boolean
@@ -24,7 +24,7 @@ export interface UsePaymentVerificationResult {
 
 export function usePaymentVerification({
   invoice,
-  invoiceId,
+  contentHash,
   txHash,
   exactTotal,
   enabled = true,
@@ -106,15 +106,15 @@ export function usePaymentVerification({
     const progress: ConfirmationProgress = { current, required }
     setTxBlockNumber(receiptBlockNumber)
     setLocalConfirmations(progress)
-    setConfirmationsRef.current(invoiceId, progress)
+    setConfirmationsRef.current(contentHash, progress)
     setVerifyDone(true)
-  }, [chainId, currentBlock, invoiceId])
+  }, [chainId, currentBlock, contentHash])
 
   const handleVerifyError = useCallback((result: VerificationResult) => {
     const errorMsg = result.error ?? "Transaction amount doesn't match the expected total"
-    setStoreErrorRef.current(invoiceId, errorMsg)
+    setStoreErrorRef.current(contentHash, errorMsg)
     setVerifyError(errorMsg)
-  }, [invoiceId])
+  }, [contentHash])
 
   // Phase 1a: verify ERC-20 synchronously when receipt arrives
   useEffect(() => {
@@ -165,7 +165,7 @@ export function usePaymentVerification({
   useEffect(() => {
     if (!enabled) return
     if (!nativeFetchError) return
-    setStoreErrorRef.current(invoiceId, nativeFetchError)
+    setStoreErrorRef.current(contentHash, nativeFetchError)
     setVerifyError(nativeFetchError)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nativeFetchError])
@@ -180,10 +180,10 @@ export function usePaymentVerification({
     const progress: ConfirmationProgress = { current, required: requiredConfirmations }
 
     setLocalConfirmations(progress)
-    setConfirmationsRef.current(invoiceId, progress)
+    setConfirmationsRef.current(contentHash, progress)
 
     if (current >= requiredConfirmations) {
-      setValidatedRef.current(invoiceId, true)
+      setValidatedRef.current(contentHash, true)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentBlock, verifyDone, txBlockNumber])

--- a/src/features/payment/ui/SmartPayButton.tsx
+++ b/src/features/payment/ui/SmartPayButton.tsx
@@ -118,7 +118,7 @@ function getAriaLabel(
 
 export function SmartPayButton({
   invoice,
-  invoiceId,
+  contentHash,
   exactTotal,
   subtotal,
   onSuccess,
@@ -127,7 +127,7 @@ export function SmartPayButton({
 }: SmartPayButtonProps) {
   const { step: realStep, error, txHash, handlePay, handleCancel, idleSubState: realIdleSubState } = usePaymentFlow({
     invoice,
-    invoiceId,
+    contentHash,
     exactTotal,
   })
 

--- a/src/features/payment/ui/__tests__/SmartPayButton.test.tsx
+++ b/src/features/payment/ui/__tests__/SmartPayButton.test.tsx
@@ -45,6 +45,7 @@ const mockInvoice = {
 const defaultProps = {
   invoice: mockInvoice,
   invoiceId: 'INV-001',
+  contentHash: 'abc123',
   exactTotal: '1000000000000000000',
   subtotal: '1000000000000000000',
 }

--- a/src/widgets/landing/ui/__tests__/BelowFoldLoader.test.tsx
+++ b/src/widgets/landing/ui/__tests__/BelowFoldLoader.test.tsx
@@ -18,6 +18,7 @@ describe('BelowFoldLoader', () => {
     class MockIntersectionObserver implements IntersectionObserver {
       readonly root: Element | null = null
       readonly rootMargin: string
+      readonly scrollMargin: string = ''
       readonly thresholds: ReadonlyArray<number> = []
 
       constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {

--- a/src/widgets/payment-panel/__tests__/PaymentPanel.test.tsx
+++ b/src/widgets/payment-panel/__tests__/PaymentPanel.test.tsx
@@ -29,18 +29,18 @@ async function expandMoreOptions() {
 describe('PaymentPanel', () => {
   describe('pending state', () => {
     it('renders payment panel with data-testid', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByTestId('payment-panel')).toBeInTheDocument()
     })
 
     it('shows AmountDisplay with correct values', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByText('Total Due')).toBeInTheDocument()
       expect(screen.getByText('USDC')).toBeInTheDocument()
     })
 
     it('renders violet gradient bar for pending', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       const panel = screen.getByTestId('payment-panel')
       const gradientBar = panel.querySelector('[data-testid="gradient-bar"]')
       expect(gradientBar).toBeInTheDocument()
@@ -48,12 +48,12 @@ describe('PaymentPanel', () => {
     })
 
     it('shows Magic Dust exact amount when present', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByText(/Exact amount/i)).toBeInTheDocument()
     })
 
     it('renders data-status attribute', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       const panel = screen.getByTestId('payment-panel')
       expect(panel.getAttribute('data-status')).toBe('pending')
     })
@@ -64,6 +64,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
         />
@@ -76,6 +77,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
         />
@@ -87,6 +89,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
         >
@@ -101,6 +104,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
         />
@@ -113,6 +117,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
         />
@@ -125,7 +130,7 @@ describe('PaymentPanel', () => {
   describe('confirming state', () => {
     it('shows blue gradient bar', () => {
       render(
-        <PaymentPanel invoice={mockInvoice} status="confirming" txHash="0xabc123" />
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="confirming" txHash="0xabc123" />
       )
       const gradientBar = screen.getByTestId('gradient-bar')
       expect(gradientBar.className).toContain('from-blue-500')
@@ -133,7 +138,7 @@ describe('PaymentPanel', () => {
 
     it('shows pulse animation', () => {
       render(
-        <PaymentPanel invoice={mockInvoice} status="confirming" txHash="0xabc123" />
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="confirming" txHash="0xabc123" />
       )
       const gradientBar = screen.getByTestId('gradient-bar')
       expect(gradientBar.className).toContain('animate-pulse')
@@ -141,14 +146,14 @@ describe('PaymentPanel', () => {
 
     it('shows PaidConfirmation', () => {
       render(
-        <PaymentPanel invoice={mockInvoice} status="confirming" txHash="0xabc123" />
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="confirming" txHash="0xabc123" />
       )
       expect(screen.getByText('Payment Successful')).toBeInTheDocument()
     })
 
     it('does not show ActionSlot when confirming', () => {
       render(
-        <PaymentPanel invoice={mockInvoice} status="confirming" txHash="0xabc123">
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="confirming" txHash="0xabc123">
           <button>Pay Now</button>
         </PaymentPanel>
       )
@@ -159,6 +164,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="confirming"
           txHash="0xabc123"
           error="Some error"
@@ -171,19 +177,19 @@ describe('PaymentPanel', () => {
 
   describe('overdue state', () => {
     it('shows red gradient bar', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="overdue" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="overdue" />)
       const gradientBar = screen.getByTestId('gradient-bar')
       expect(gradientBar.className).toContain('from-red-500')
     })
 
     it('shows ExpiredState with expired message', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="overdue" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="overdue" />)
       expect(screen.getByText('This invoice has expired')).toBeInTheDocument()
     })
 
     it('does not show ActionSlot when overdue', () => {
       render(
-        <PaymentPanel invoice={mockInvoice} status="overdue">
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="overdue">
           <button>Pay Now</button>
         </PaymentPanel>
       )
@@ -195,7 +201,7 @@ describe('PaymentPanel', () => {
   describe('action slot (US4)', () => {
     it('renders children in ActionSlot when pending', () => {
       render(
-        <PaymentPanel invoice={mockInvoice} status="pending">
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending">
           <button>Pay Now</button>
         </PaymentPanel>
       )
@@ -203,7 +209,7 @@ describe('PaymentPanel', () => {
     })
 
     it('shows default prompt when no children on pending', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByText('Connect Wallet to Pay')).toBeInTheDocument()
     })
   })
@@ -213,6 +219,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           error="Transaction failed"
           onDismissError={() => {}}
@@ -227,6 +234,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           error="Test error"
           onDismissError={onDismiss}
@@ -238,7 +246,7 @@ describe('PaymentPanel', () => {
     })
 
     it('does not show error banner when no error', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.queryByRole('alert')).toBeNull()
     })
 
@@ -246,6 +254,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
           error="Some error"
@@ -258,7 +267,7 @@ describe('PaymentPanel', () => {
 
   describe('QR code button', () => {
     it('renders Show QR button when pending', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByRole('button', { name: /show qr/i })).toBeInTheDocument()
     })
 
@@ -266,6 +275,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
         />
@@ -274,12 +284,12 @@ describe('PaymentPanel', () => {
     })
 
     it('hides Show QR button when status is overdue', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="overdue" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="overdue" />)
       expect(screen.queryByRole('button', { name: /show qr/i })).toBeNull()
     })
 
     it('Show QR button is always visible on all screen sizes', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       const btn = screen.getByRole('button', { name: /show qr/i })
       expect(btn.className).not.toContain('hidden')
     })
@@ -287,20 +297,20 @@ describe('PaymentPanel', () => {
 
   describe('footer', () => {
     it('renders Download PDF button (enabled)', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       const downloadBtn = screen.getByRole('button', { name: /download pdf/i })
       expect(downloadBtn).toBeInTheDocument()
       expect(downloadBtn).not.toBeDisabled()
     })
 
     it('renders Report abuse button', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       const reportBtn = screen.getByRole('button', { name: /report abuse/i })
       expect(reportBtn).toBeInTheDocument()
     })
 
     it('Report button opens mailto link', async () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       const reportBtn = screen.getByRole('button', { name: /report abuse/i })
       const hrefSpy = vi.spyOn(window.location, 'href', 'set')
       await userEvent.click(reportBtn)
@@ -314,6 +324,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
         />
@@ -323,13 +334,13 @@ describe('PaymentPanel', () => {
     })
 
     it('does not render View Tx link in footer when pending', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.queryByRole('link', { name: /view tx/i })).toBeNull()
     })
 
     it('renders gradient separator', () => {
       const { container } = render(
-        <PaymentPanel invoice={mockInvoice} status="pending" />
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />
       )
       const separator = container.querySelector('.via-zinc-800')
       expect(separator).toBeInTheDocument()
@@ -343,7 +354,7 @@ describe('PaymentPanel', () => {
         total: undefined,
         magicDust: undefined,
       }
-      render(<PaymentPanel invoice={invoiceNoTotal} status="pending" />)
+      render(<PaymentPanel invoice={invoiceNoTotal} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByText('Total Due')).toBeInTheDocument()
     })
 
@@ -354,7 +365,7 @@ describe('PaymentPanel', () => {
         total: '100',
         magicDust: '5',
       }
-      render(<PaymentPanel invoice={integerInvoice} status="pending" />)
+      render(<PaymentPanel invoice={integerInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByText('Total Due')).toBeInTheDocument()
     })
 
@@ -364,7 +375,7 @@ describe('PaymentPanel', () => {
         total: '1500000000',
         magicDust: undefined,
       }
-      render(<PaymentPanel invoice={noMagicDust} status="pending" />)
+      render(<PaymentPanel invoice={noMagicDust} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByText('Manual verification required')).toBeInTheDocument()
     })
 
@@ -372,6 +383,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status={'unknown' as any}
         />
       )
@@ -382,6 +394,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
         />
       )
@@ -399,6 +412,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onIvePaid={vi.fn()}
           onCheckPayment={vi.fn()}
@@ -414,14 +428,14 @@ describe('PaymentPanel', () => {
 
     it("renders only I've paid when onCheckPayment is not provided", () => {
       render(
-        <PaymentPanel invoice={mockInvoice} status="pending" onIvePaid={vi.fn()} />
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" onIvePaid={vi.fn()} />
       )
       expect(screen.getByTestId('ive-paid-button')).toBeInTheDocument()
       expect(screen.queryByTestId('check-payment-button')).toBeNull()
     })
 
     it("does not render I've paid button when onIvePaid is not provided", () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.queryByTestId('ive-paid-button')).toBeNull()
     })
 
@@ -429,6 +443,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
           onIvePaid={vi.fn()}
@@ -440,7 +455,7 @@ describe('PaymentPanel', () => {
     it("calls onIvePaid when button is clicked", async () => {
       const onIvePaid = vi.fn()
       render(
-        <PaymentPanel invoice={mockInvoice} status="pending" onIvePaid={onIvePaid} />
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" onIvePaid={onIvePaid} />
       )
       await userEvent.click(screen.getByTestId('ive-paid-button'))
       expect(onIvePaid).toHaveBeenCalledOnce()
@@ -451,6 +466,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onCheckPayment={onCheckPayment}
         />
@@ -464,6 +480,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onCheckPayment={vi.fn()}
           cooldownUntil={cooldownUntil}
@@ -479,6 +496,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onCheckPayment={vi.fn()}
           cooldownUntil={cooldownUntil}
@@ -493,6 +511,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
           onCheckPayment={vi.fn()}
@@ -507,6 +526,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onStartWatching={vi.fn()}
         />
@@ -516,7 +536,7 @@ describe('PaymentPanel', () => {
     })
 
     it('does not render "More options" when neither watch nor verify is provided', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.queryByTestId('more-options-toggle')).toBeNull()
     })
 
@@ -524,6 +544,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onVerifyTxHash={vi.fn()}
         />
@@ -536,6 +557,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onStartWatching={vi.fn()}
         />
@@ -550,6 +572,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onStartWatching={vi.fn()}
         />
@@ -567,6 +590,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onStartWatching={vi.fn()}
         />
@@ -581,6 +605,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onStartWatching={onStartWatching}
         />
@@ -594,6 +619,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onStartWatching={vi.fn()}
           onStopWatching={vi.fn()}
@@ -611,6 +637,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onStartWatching={vi.fn()}
           onStopWatching={onStopWatching}
@@ -626,6 +653,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
           onStartWatching={vi.fn()}
@@ -638,7 +666,7 @@ describe('PaymentPanel', () => {
 
   describe('PollingStatus filtering', () => {
     it('does not show PollingStatus when pollingMode is auto-check', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" pollingMode="auto-check" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" pollingMode="auto-check" />)
       expect(screen.queryByText('Checking...')).toBeNull()
     })
 
@@ -646,6 +674,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           pollingMode="aggressive"
           onIvePaid={vi.fn()}
@@ -657,12 +686,12 @@ describe('PaymentPanel', () => {
     })
 
     it('shows PollingStatus for watching mode', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" pollingMode="watching" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" pollingMode="watching" />)
       expect(screen.getByText('Watching for payment...')).toBeInTheDocument()
     })
 
     it('does not show PollingStatus for idle mode', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" pollingMode="idle" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" pollingMode="idle" />)
       expect(screen.queryByText('Checking...')).toBeNull()
       expect(screen.queryByText('Watching for payment...')).toBeNull()
     })
@@ -673,6 +702,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onIvePaid={vi.fn()}
           onStartWatching={vi.fn()}
@@ -690,6 +720,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onVerifyTxHash={vi.fn()}
         />
@@ -700,7 +731,7 @@ describe('PaymentPanel', () => {
     })
 
     it('does not render when onVerifyTxHash is not provided', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.queryByTestId('more-options-toggle')).toBeNull()
     })
 
@@ -708,6 +739,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onVerifyTxHash={vi.fn()}
         />
@@ -721,6 +753,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onVerifyTxHash={vi.fn()}
         />
@@ -734,6 +767,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onVerifyTxHash={vi.fn()}
         />
@@ -747,6 +781,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onVerifyTxHash={vi.fn()}
         />
@@ -762,6 +797,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onVerifyTxHash={onVerifyTxHash}
         />
@@ -776,6 +812,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
           onVerifyTxHash={vi.fn()}
@@ -788,6 +825,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onVerifyTxHash={vi.fn()}
         />
@@ -803,6 +841,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           onVerifyTxHash={vi.fn()}
         />
@@ -818,6 +857,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           error="Network error"
           onDismissError={() => {}}
@@ -830,6 +870,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="pending"
           error="Test"
           onDismissError={() => {}}
@@ -839,17 +880,17 @@ describe('PaymentPanel', () => {
     })
 
     it('MagicDustBadge renders for pending state with dust', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByText(/Exact amount/i)).toBeInTheDocument()
     })
 
     it('Download PDF button has aria-label', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByRole('button', { name: /download pdf/i })).toBeInTheDocument()
     })
 
     it('Report abuse button has aria-label', () => {
-      render(<PaymentPanel invoice={mockInvoice} status="pending" />)
+      render(<PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" />)
       expect(screen.getByRole('button', { name: /report abuse/i })).toBeInTheDocument()
     })
 
@@ -857,6 +898,7 @@ describe('PaymentPanel', () => {
       render(
         <PaymentPanel
           invoice={mockInvoice}
+          contentHash="test-content-hash"
           status="paid"
           txHash="0xabc123"
         />
@@ -868,7 +910,7 @@ describe('PaymentPanel', () => {
 
     it("I've paid button has descriptive aria-label", () => {
       render(
-        <PaymentPanel invoice={mockInvoice} status="pending" onIvePaid={vi.fn()} />
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="pending" onIvePaid={vi.fn()} />
       )
       const btn = screen.getByTestId('ive-paid-button')
       expect(btn.getAttribute('aria-label')).toContain('already paid')
@@ -876,7 +918,7 @@ describe('PaymentPanel', () => {
 
     it('gradient bar respects reduced motion', () => {
       render(
-        <PaymentPanel invoice={mockInvoice} status="confirming" txHash="0xabc123" />
+        <PaymentPanel invoice={mockInvoice} contentHash="test-content-hash" status="confirming" txHash="0xabc123" />
       )
       const gradientBar = screen.getByTestId('gradient-bar')
       expect(gradientBar.className).toContain('motion-safe:animate-pulse')

--- a/src/widgets/payment-panel/model/use-invoice-view.ts
+++ b/src/widgets/payment-panel/model/use-invoice-view.ts
@@ -101,7 +101,7 @@ export function useInvoiceView({ source }: UseInvoiceViewOptions): InvoiceViewSt
   )
   const polling = usePaymentPolling({
     enabled: !!invoice,
-    invoiceId: contentHash,
+    contentHash,
     toAddress: invoice?.from?.walletAddress ?? '',
     chainId: networkId,
     ...(invoice?.tokenAddress ? { contractAddress: invoice.tokenAddress } : {}),

--- a/src/widgets/payment-panel/model/use-invoice-view.ts
+++ b/src/widgets/payment-panel/model/use-invoice-view.ts
@@ -48,6 +48,7 @@ export interface UseInvoiceViewOptions {
 
 export interface InvoiceViewState {
   invoice: Invoice | null
+  contentHash: string
   errorType: DecodeErrorType | null
   isLoading: boolean
   panelStatus: InvoiceStatus
@@ -72,10 +73,11 @@ export function useInvoiceView({ source }: UseInvoiceViewOptions): InvoiceViewSt
 
   const [isHydrated, setIsHydrated] = useState(false)
   const [invoice, setInvoice] = useState<Invoice | null>(null)
+  const [contentHash, setContentHash] = useState<string>('')
   const [errorType, setErrorType] = useState<DecodeErrorType | null>(null)
 
   const tracked = useTrackedInvoiceStore((s) =>
-    invoice ? s.invoices.find((inv) => inv.invoiceId === invoice.invoiceId) : undefined
+    contentHash ? s.invoices.find((inv) => inv.contentHash === contentHash) : undefined
   )
 
   const panelStatus = computeInvoiceStatus({
@@ -99,7 +101,7 @@ export function useInvoiceView({ source }: UseInvoiceViewOptions): InvoiceViewSt
   )
   const polling = usePaymentPolling({
     enabled: !!invoice,
-    invoiceId: invoice?.invoiceId ?? '',
+    invoiceId: contentHash,
     toAddress: invoice?.from?.walletAddress ?? '',
     chainId: networkId,
     ...(invoice?.tokenAddress ? { contractAddress: invoice.tokenAddress } : {}),
@@ -154,12 +156,14 @@ export function useInvoiceView({ source }: UseInvoiceViewOptions): InvoiceViewSt
 
       if (result.success) {
         setInvoice(result.data)
+        setContentHash(result.contentHash)
         setErrorType(null)
         // Clear any stored error from previous session on fresh page load
-        setError(result.data.invoiceId, null)
+        setError(result.contentHash, null)
 
         try {
           trackView({
+            contentHash: result.contentHash,
             invoiceId: result.data.invoiceId,
             invoiceUrl: `${window.location.origin}/pay#${hash}`,
             source,
@@ -188,16 +192,16 @@ export function useInvoiceView({ source }: UseInvoiceViewOptions): InvoiceViewSt
   }, [hash, isHydrated, trackView, source, setError])
 
   const dismissError = useCallback(() => {
-    if (invoice) setError(invoice.invoiceId, null)
-  }, [invoice, setError])
+    if (contentHash) setError(contentHash, null)
+  }, [contentHash, setError])
 
   // Manual txHash escape hatch
   const verifyTxHash = useCallback(({ txHash: hash }: { txHash: string }) => {
-    if (!invoice || !/^0x[a-fA-F0-9]{64}$/.test(hash)) return
+    if (!contentHash || !/^0x[a-fA-F0-9]{64}$/.test(hash)) return
 
     const store = useTrackedInvoiceStore.getState()
 
-    const current = store.invoices.find((inv) => inv.invoiceId === invoice.invoiceId)
+    const current = store.invoices.find((inv) => inv.contentHash === contentHash)
     if (current?.txHash === hash) {
       toast.info('This transaction is already linked to this invoice')
       return
@@ -205,20 +209,21 @@ export function useInvoiceView({ source }: UseInvoiceViewOptions): InvoiceViewSt
 
     // W3-006: reject if already linked to a different invoice
     const alreadyLinked = store.invoices.some(
-      (inv) => inv.txHash === hash && inv.invoiceId !== invoice.invoiceId,
+      (inv) => inv.txHash === hash && inv.contentHash !== contentHash,
     )
     if (alreadyLinked) {
       toast.error('This transaction is already linked to another invoice')
       return
     }
 
-    setTxHash(invoice.invoiceId, hash as `0x${string}`, false)
-  }, [invoice, setTxHash])
+    setTxHash(contentHash, hash as `0x${string}`, false)
+  }, [contentHash, setTxHash])
 
   const isLoading = !invoice && !errorType
 
   return {
     invoice,
+    contentHash,
     errorType,
     isLoading,
     panelStatus,

--- a/src/widgets/payment-panel/types.ts
+++ b/src/widgets/payment-panel/types.ts
@@ -18,6 +18,8 @@ export type { ConfirmationProgress } from '@/shared/lib/invoice-types'
 export interface PaymentPanelProps {
   /** Full decoded invoice data */
   invoice: Invoice
+  /** Content hash for store lookups */
+  contentHash: string
   /** Computed status (parent determines overdue from dueAt) */
   status: PaymentPanelStatus
   /** Invoice source: created by or received by user */

--- a/src/widgets/payment-panel/ui/DevStatusToggle.tsx
+++ b/src/widgets/payment-panel/ui/DevStatusToggle.tsx
@@ -6,7 +6,7 @@ import { useTrackedInvoiceStore } from '@/entities/invoice'
 import type { PaymentPanelStatus } from '../types'
 
 interface DevStatusToggleProps {
-  invoiceId: string
+  contentHash: string
   status: PaymentPanelStatus
 }
 
@@ -26,7 +26,7 @@ const FAKE_TX = ('0x' + '0'.repeat(64)) as `0x${string}`
  * Inner component with hooks — only mounted in development.
  * Never imported/rendered in production → dead code eliminated by minifier.
  */
-function DevStatusToggleInner({ invoiceId }: DevStatusToggleProps) {
+function DevStatusToggleInner({ contentHash }: DevStatusToggleProps) {
   const { setTxHash, setConfirmations, setError, resetPaymentState } =
     useTrackedInvoiceStore(useShallow((s) => ({
       setTxHash: s.setTxHash,
@@ -41,18 +41,18 @@ function DevStatusToggleInner({ invoiceId }: DevStatusToggleProps) {
     setIdx(next)
 
     // Reset error on every cycle
-    setError(invoiceId, null)
+    setError(contentHash, null)
 
     switch (next) {
       case 0: // pending — clear all payment facts
-        resetPaymentState(invoiceId)
+        resetPaymentState(contentHash)
         break
       case 1: // confirming — unvalidated tx with partial confirmations
-        setTxHash(invoiceId, FAKE_TX, false)
-        setConfirmations(invoiceId, { current: 8, required: 15 })
+        setTxHash(contentHash, FAKE_TX, false)
+        setConfirmations(contentHash, { current: 8, required: 15 })
         break
       case 2: // paid — validated tx
-        setTxHash(invoiceId, FAKE_TX, true)
+        setTxHash(contentHash, FAKE_TX, true)
         break
     }
   }

--- a/src/widgets/payment-panel/ui/PaymentPanel.tsx
+++ b/src/widgets/payment-panel/ui/PaymentPanel.tsx
@@ -28,6 +28,7 @@ const QRModal = dynamic(
 
 export function PaymentPanel({
   invoice,
+  contentHash,
   status,
   txHash,
   confirmations,
@@ -53,8 +54,8 @@ export function PaymentPanel({
   const handlePdfExport = useCallback(() => {
     track(AnalyticsEvent.PDF_EXPORT, { source: 'button' })
     const invoiceUrl = typeof window !== 'undefined' ? window.location.href : undefined
-    const tracked = invoice.invoiceId
-      ? useTrackedInvoiceStore.getState().getInvoice(invoice.invoiceId)
+    const tracked = contentHash
+      ? useTrackedInvoiceStore.getState().getInvoice(contentHash)
       : undefined
     const paidAt = tracked?.paidAt
       ? Math.floor(new Date(tracked.paidAt).getTime() / 1000)
@@ -65,7 +66,7 @@ export function PaymentPanel({
       invoiceUrl,
       paidAt,
     })
-  }, [invoice, status, txHash])
+  }, [contentHash, invoice, status, txHash])
 
   const cooldownSeconds = useCooldown(cooldownUntil)
 


### PR DESCRIPTION
## Problem

`rich-invoice-store.ts` used `invoiceId` (user-set display label like `INV-2026-001`) as the upsert key, causing silent data loss when different senders used the same invoice ID.

## Solution

Key invoices by `contentHash` — SHA-256 digest of the URL fragment (content-derived, crypto-grade):

1. Added `computeContentHash(fragment)` to `features/invoice-codec` — sync SHA-256 via `@noble/hashes`
2. Added `contentHash` field to `TrackedInvoice` interface as the unique storage key
3. Updated all store actions to use `contentHash` for lookups instead of `invoiceId`
4. Updated `parseInvoiceHash` to return `contentHash` alongside decoded invoice
5. **Synchronous migration v1→v2** — computes contentHash atomically inside zustand `migrate()` using `@noble/hashes/sha2` (sync), no post-hydration phase
6. Updated all consumer hooks and components to pass `contentHash`
7. Kept `invoiceId` as display-only field

### Why SHA-256 instead of raw fragment?
- **ERC-3009 nonce**: `contentHash` is bytes32-compatible (32 bytes / 64 hex). Will serve as deterministic `transferWithAuthorization` nonce for x402 payment matching — given an invoice, compute hash → find tx on-chain by nonce
- **Codec library**: `computeContentHash` ships with the codec npm package
- **Compact**: 64 hex chars vs 100-500 char raw fragment

### Why sync @noble/hashes instead of async crypto.subtle?
- **Atomic migration**: zustand persist `migrate()` must be synchronous — async created a two-phase migration where the store was persisted with empty `contentHash` between phases, causing data loss
- **Zero new deps**: `@noble/hashes` is already a dependency via viem
- **Audited**: Trail of Bits + Cure53 audited, same author as `@noble/curves`
- **Same output**: NIST SHA-256 (FIPS 180-4), byte-identical to `crypto.subtle.digest`

### Builds on PR #81
This reworks the approach from #81 by @ShoaibAnsari with architectural changes: `key` → `contentHash` naming, SHA-256 crypto hash instead of raw fragment, codec placement, and synchronous migration. Collision prevention test scenarios preserved.

## Post-review fixes

- **Sync SHA-256 migration**: replaced async `crypto.subtle` two-phase migration with atomic sync `@noble/hashes` inside `migrate()` — eliminates store data loss, hydration race conditions, history page flickering, and infinite migration loop (~55 lines of async infrastructure removed)
- **Debug panel**: shows full invoice data instead of decode flag for better DX
- **Security hardening**: runtime safety and perf improvements
- **Cleanup**: removed leftover `console.info` logs, fixed test type errors

## Scope

- `src/features/invoice-codec/lib/content-hash.ts` — sync SHA-256 via `@noble/hashes`
- `src/entities/invoice/model/rich-invoice-store.ts` — store key change + atomic sync migration
- `src/widgets/payment-panel/model/use-invoice-view.ts` — expose contentHash
- `src/features/generate-link/lib/generate-invoice.ts` — compute on creation
- `src/features/payment/model/use-*.ts` — all hooks use contentHash
- `src/app/(app)/pay/*` and `src/app/(app)/invoice/*` — pass contentHash
- All corresponding test files (15 files updated)

## Testing

- All tests pass (2,650+)
- New `computeContentHash` unit tests (determinism, uniqueness, edge cases)
- Collision prevention test cases
- Type-check + lint clean

Closes #47