### PR TITLE
refactor(creator-store): extract CREATOR_INITIAL_STATE as single source of truth (TD-11)

### DIFF
--- a/src/entities/creator/model/__tests__/initialState.test.ts
+++ b/src/entities/creator/model/__tests__/initialState.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CREATOR_INITIAL_STATE } from '../initial-state'
+import { useCreatorStore } from '../useCreatorStore'
+
+describe('CREATOR_INITIAL_STATE', () => {
+  it('matches canonical shape snapshot', () => {
+    expect(CREATOR_INITIAL_STATE).toMatchInlineSnapshot(`
+      {
+        "activeDraft": null,
+        "idCounter": {
+          "currentValue": 1,
+          "prefix": "INV",
+        },
+        "lineItems": [],
+        "preferences": {},
+        "templates": [],
+        "version": 1,
+      }
+    `)
+  })
+
+  it('contains all fields persisted by partialize', () => {
+    const persistedKeys = ['version', 'activeDraft', 'lineItems', 'templates', 'preferences', 'idCounter'] as const
+    for (const key of persistedKeys) {
+      expect(CREATOR_INITIAL_STATE).toHaveProperty(key)
+    }
+  })
+})
+
+describe('clearAllData', () => {
+  beforeEach(() => {
+    useCreatorStore.setState({
+      activeDraft: null,
+      lineItems: [],
+      templates: [],
+      preferences: {},
+    })
+  })
+
+  it('resets persisted fields to CREATOR_INITIAL_STATE values', () => {
+    // Set some non-initial state
+    useCreatorStore.setState({
+      templates: [
+        {
+          id: 'tpl-1',
+          name: 'Test Template',
+          data: { invoiceId: 'T-001', networkId: 1, currency: 'USDC', decimals: 6 },
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+      preferences: { defaultNetworkId: 137 },
+    })
+
+    useCreatorStore.getState().clearAllData()
+
+    const state = useCreatorStore.getState()
+    expect(state.version).toBe(CREATOR_INITIAL_STATE.version)
+    expect(state.activeDraft).toBe(CREATOR_INITIAL_STATE.activeDraft)
+    expect(state.lineItems).toEqual(CREATOR_INITIAL_STATE.lineItems)
+    expect(state.templates).toEqual(CREATOR_INITIAL_STATE.templates)
+    expect(state.preferences).toEqual(CREATOR_INITIAL_STATE.preferences)
+    expect(state.idCounter).toEqual(CREATOR_INITIAL_STATE.idCounter)
+  })
+
+  it('post-reset state deep-equals CREATOR_INITIAL_STATE for all persisted fields', () => {
+    useCreatorStore.getState().clearAllData()
+
+    const state = useCreatorStore.getState()
+    const persistedKeys = Object.keys(CREATOR_INITIAL_STATE) as Array<keyof typeof CREATOR_INITIAL_STATE>
+    for (const key of persistedKeys) {
+      expect(state[key]).toEqual(CREATOR_INITIAL_STATE[key])
+    }
+  })
+})
+
+describe('migrate() fallback on corrupted input', () => {
+  it('rehydrates store to CREATOR_INITIAL_STATE shape when localStorage contains corrupted data', async () => {
+    // Simulate corrupted localStorage: version mismatch with unparseable state
+    const corruptedEntry = JSON.stringify({
+      state: null,
+      version: 0,
+    })
+    localStorage.setItem('voidpay:creator', corruptedEntry)
+
+    // Trigger rehydration by calling hydrate()
+    await useCreatorStore.persist.rehydrate()
+
+    const state = useCreatorStore.getState()
+
+    // After corruption recovery, all persisted fields should match CREATOR_INITIAL_STATE
+    expect(state.version).toBe(CREATOR_INITIAL_STATE.version)
+    expect(state.activeDraft).toBe(CREATOR_INITIAL_STATE.activeDraft)
+    expect(state.lineItems).toEqual(CREATOR_INITIAL_STATE.lineItems)
+    expect(state.templates).toEqual(CREATOR_INITIAL_STATE.templates)
+    expect(state.idCounter).toEqual(CREATOR_INITIAL_STATE.idCounter)
+  })
+})

--- a/src/entities/creator/model/__tests__/initialState.test.ts
+++ b/src/entities/creator/model/__tests__/initialState.test.ts
@@ -42,11 +42,10 @@ describe('clearAllData', () => {
     useCreatorStore.setState({
       templates: [
         {
-          id: 'tpl-1',
+          templateId: 'tpl-1',
           name: 'Test Template',
-          data: { invoiceId: 'T-001', networkId: 1, currency: 'USDC', decimals: 6 },
+          invoiceData: { invoiceId: 'T-001', networkId: 1, currency: 'USDC', decimals: 6 },
           createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
         },
       ],
       preferences: { defaultNetworkId: 137 },

--- a/src/entities/creator/model/initial-state.ts
+++ b/src/entities/creator/model/initial-state.ts
@@ -1,0 +1,27 @@
+/**
+ * Creator Store — Canonical Initial State
+ *
+ * Single source of truth for the persisted fields reset.
+ * Used by:
+ *   - useCreatorStore: migrate() fallback on data corruption
+ *   - utilitySlice: clearAllData() action
+ *
+ * Must match the fields listed in `partialize` (useCreatorStore.ts).
+ */
+
+import type { CreatorStore } from './slices/types'
+
+export const CREATOR_INITIAL_STATE: Pick<
+  CreatorStore,
+  'version' | 'activeDraft' | 'lineItems' | 'templates' | 'preferences' | 'idCounter'
+> = {
+  version: 1,
+  activeDraft: null,
+  lineItems: [],
+  templates: [],
+  preferences: {},
+  idCounter: {
+    currentValue: 1,
+    prefix: 'INV',
+  },
+} as const

--- a/src/entities/creator/model/slices/utilitySlice.ts
+++ b/src/entities/creator/model/slices/utilitySlice.ts
@@ -7,6 +7,7 @@
 
 import type { StateCreator } from 'zustand'
 import type { CreatorStore } from './types'
+import { CREATOR_INITIAL_STATE } from '../initial-state'
 
 /**
  * Utility Slice State
@@ -21,27 +22,12 @@ export interface UtilitySlice {
 }
 
 /**
- * Initial state for reset
- */
-const initialState = {
-  version: 1 as const,
-  activeDraft: null,
-  lineItems: [],
-  templates: [],
-  preferences: {},
-  idCounter: {
-    currentValue: 1,
-    prefix: 'INV',
-  },
-}
-
-/**
  * Create Utility Slice
  */
 export const createUtilitySlice: StateCreator<CreatorStore, [], [], UtilitySlice> = (set) => ({
   // ========== Utility ==========
 
   clearAllData: () => {
-    set(initialState)
+    set(CREATOR_INITIAL_STATE)
   },
 })

--- a/src/entities/creator/model/useCreatorStore.ts
+++ b/src/entities/creator/model/useCreatorStore.ts
@@ -23,21 +23,7 @@ import {
   createUiSlice,
   type CreatorStore,
 } from './slices'
-
-/**
- * Initial state
- */
-const initialState = {
-  version: 1 as const,
-  activeDraft: null,
-  lineItems: [],
-  templates: [],
-  preferences: {},
-  idCounter: {
-    currentValue: 1,
-    prefix: 'INV',
-  },
-}
+import { CREATOR_INITIAL_STATE } from './initial-state'
 
 /**
  * Migration function for future schema versions
@@ -93,7 +79,7 @@ const migrate = (persistedState: any, version: number): Partial<CreatorStore> =>
     }
 
     // Return initial state for data corruption
-    return initialState
+    return CREATOR_INITIAL_STATE
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #110 (tech-debt p1, delegated by Kai).

Two identical `initialState` definitions existed independently in `useCreatorStore.ts` (migrate() fallback) and `slices/utilitySlice.ts` (clearAllData() action). Silent divergence risk: adding a field to one would not produce a TypeScript error from the other.

**This PR:**
- Creates `src/entities/creator/model/initial-state.ts` with `CREATOR_INITIAL_STATE` typed as `Pick<CreatorStore, ...>` covering all persisted fields
- Removes both local `initialState` blocks
- Imports `CREATOR_INITIAL_STATE` in both callsites

## Tests added

- Snapshot test locking canonical shape of `CREATOR_INITIAL_STATE`
- `clearAllData()` reset behavior test
- `migrate()` fallback path test via corrupted localStorage simulation

## Validation

- Tests: 99/99 passed (8 test files)
- tsc: clean
- ESLint: No issues found