### PR TITLE
fix(payment): suppress payment-progress toast on mobile (GH#215)

### DIFF
--- a/src/features/payment/model/__tests__/use-payment-toast.test.ts
+++ b/src/features/payment/model/__tests__/use-payment-toast.test.ts
@@ -3,6 +3,8 @@ import { renderHook } from '@testing-library/react'
 import { toast as sonnerToast } from 'sonner'
 import { usePaymentToast } from '../use-payment-toast'
 
+type UsePaymentToastParams = Parameters<typeof usePaymentToast>[0]
+
 // sonner is aliased to mocks/sonner.tsx in vitest.config.ts
 // toast.loading / toast.success / toast.error / toast.dismiss are vi.fn()
 
@@ -23,8 +25,8 @@ function setMatchMedia(matchesMobile: boolean): void {
   })
 }
 
-const BASE_PARAMS = {
-  idleSubState: 'ready' as const,
+const BASE_PARAMS: Omit<UsePaymentToastParams, 'step'> = {
+  idleSubState: 'ready',
   currency: 'USDC',
   subtotal: '1000000',
   decimals: 6,
@@ -43,10 +45,10 @@ describe('usePaymentToast', () => {
     it('calls sonnerToast.loading when an active step is present', () => {
       const { rerender } = renderHook(
         (props) => usePaymentToast(props),
-        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+        { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
-      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+      rerender({ ...BASE_PARAMS, step: 'sending' })
 
       expect(sonnerToast.loading).toHaveBeenCalled()
     })
@@ -54,11 +56,11 @@ describe('usePaymentToast', () => {
     it('calls sonnerToast.success on success step', () => {
       const { rerender } = renderHook(
         (props) => usePaymentToast(props),
-        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+        { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
-      rerender({ ...BASE_PARAMS, step: 'sending' as const })
-      rerender({ ...BASE_PARAMS, step: 'success' as const })
+      rerender({ ...BASE_PARAMS, step: 'sending' })
+      rerender({ ...BASE_PARAMS, step: 'success' })
 
       expect(sonnerToast.success).toHaveBeenCalled()
     })
@@ -66,13 +68,13 @@ describe('usePaymentToast', () => {
     it('calls sonnerToast.error on payment failure', () => {
       const { rerender } = renderHook(
         (props) => usePaymentToast(props),
-        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+        { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
-      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+      rerender({ ...BASE_PARAMS, step: 'sending' })
       rerender({
         ...BASE_PARAMS,
-        step: 'idle' as const,
+        step: 'idle',
         error: { message: 'User rejected' },
       })
 
@@ -86,11 +88,11 @@ describe('usePaymentToast', () => {
     it('does NOT call sonnerToast.loading during step transitions', () => {
       const { rerender } = renderHook(
         (props) => usePaymentToast(props),
-        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+        { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
-      rerender({ ...BASE_PARAMS, step: 'sending' as const })
-      rerender({ ...BASE_PARAMS, step: 'confirming' as const })
+      rerender({ ...BASE_PARAMS, step: 'sending' })
+      rerender({ ...BASE_PARAMS, step: 'confirming' })
 
       expect(sonnerToast.loading).not.toHaveBeenCalled()
     })
@@ -98,11 +100,11 @@ describe('usePaymentToast', () => {
     it('still calls sonnerToast.success on success step', () => {
       const { rerender } = renderHook(
         (props) => usePaymentToast(props),
-        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+        { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
-      rerender({ ...BASE_PARAMS, step: 'sending' as const })
-      rerender({ ...BASE_PARAMS, step: 'success' as const })
+      rerender({ ...BASE_PARAMS, step: 'sending' })
+      rerender({ ...BASE_PARAMS, step: 'success' })
 
       expect(sonnerToast.success).toHaveBeenCalled()
       expect(sonnerToast.loading).not.toHaveBeenCalled()
@@ -111,13 +113,13 @@ describe('usePaymentToast', () => {
     it('still calls sonnerToast.error on payment failure', () => {
       const { rerender } = renderHook(
         (props) => usePaymentToast(props),
-        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+        { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
-      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+      rerender({ ...BASE_PARAMS, step: 'sending' })
       rerender({
         ...BASE_PARAMS,
-        step: 'idle' as const,
+        step: 'idle',
         error: { message: 'User rejected' },
       })
 
@@ -128,11 +130,11 @@ describe('usePaymentToast', () => {
     it('calls sonnerToast.dismiss on user cancel', () => {
       const { rerender } = renderHook(
         (props) => usePaymentToast(props),
-        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+        { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
-      rerender({ ...BASE_PARAMS, step: 'sending' as const })
-      rerender({ ...BASE_PARAMS, step: 'idle' as const, error: null })
+      rerender({ ...BASE_PARAMS, step: 'sending' })
+      rerender({ ...BASE_PARAMS, step: 'idle', error: null })
 
       expect(sonnerToast.dismiss).toHaveBeenCalled()
     })
@@ -147,16 +149,16 @@ describe('usePaymentToast', () => {
         {
           initialProps: {
             ...BASE_PARAMS,
-            idleSubState: 'disconnected' as const,
-            step: 'idle' as const,
+            idleSubState: 'disconnected',
+            step: 'idle',
           },
         },
       )
 
       rerender({
         ...BASE_PARAMS,
-        idleSubState: 'disconnected' as const,
-        step: 'connecting' as const,
+        idleSubState: 'disconnected',
+        step: 'connecting',
       })
 
       expect(sonnerToast.loading).not.toHaveBeenCalled()

--- a/src/features/payment/model/__tests__/use-payment-toast.test.ts
+++ b/src/features/payment/model/__tests__/use-payment-toast.test.ts
@@ -44,7 +44,7 @@ describe('usePaymentToast', () => {
 
     it('calls sonnerToast.loading when an active step is present', () => {
       const { rerender } = renderHook(
-        (props) => usePaymentToast(props),
+        (props: UsePaymentToastParams) => usePaymentToast(props),
         { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
@@ -55,7 +55,7 @@ describe('usePaymentToast', () => {
 
     it('calls sonnerToast.success on success step', () => {
       const { rerender } = renderHook(
-        (props) => usePaymentToast(props),
+        (props: UsePaymentToastParams) => usePaymentToast(props),
         { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
@@ -67,7 +67,7 @@ describe('usePaymentToast', () => {
 
     it('calls sonnerToast.error on payment failure', () => {
       const { rerender } = renderHook(
-        (props) => usePaymentToast(props),
+        (props: UsePaymentToastParams) => usePaymentToast(props),
         { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
@@ -87,7 +87,7 @@ describe('usePaymentToast', () => {
 
     it('does NOT call sonnerToast.loading during step transitions', () => {
       const { rerender } = renderHook(
-        (props) => usePaymentToast(props),
+        (props: UsePaymentToastParams) => usePaymentToast(props),
         { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
@@ -99,7 +99,7 @@ describe('usePaymentToast', () => {
 
     it('still calls sonnerToast.success on success step', () => {
       const { rerender } = renderHook(
-        (props) => usePaymentToast(props),
+        (props: UsePaymentToastParams) => usePaymentToast(props),
         { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
@@ -112,7 +112,7 @@ describe('usePaymentToast', () => {
 
     it('still calls sonnerToast.error on payment failure', () => {
       const { rerender } = renderHook(
-        (props) => usePaymentToast(props),
+        (props: UsePaymentToastParams) => usePaymentToast(props),
         { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
@@ -129,7 +129,7 @@ describe('usePaymentToast', () => {
 
     it('calls sonnerToast.dismiss on user cancel', () => {
       const { rerender } = renderHook(
-        (props) => usePaymentToast(props),
+        (props: UsePaymentToastParams) => usePaymentToast(props),
         { initialProps: { ...BASE_PARAMS, step: 'idle' } },
       )
 
@@ -145,7 +145,7 @@ describe('usePaymentToast', () => {
 
     it('does NOT call sonnerToast.loading for connecting step', () => {
       const { rerender } = renderHook(
-        (props) => usePaymentToast(props),
+        (props: UsePaymentToastParams) => usePaymentToast(props),
         {
           initialProps: {
             ...BASE_PARAMS,

--- a/src/features/payment/model/__tests__/use-payment-toast.test.ts
+++ b/src/features/payment/model/__tests__/use-payment-toast.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { toast as sonnerToast } from 'sonner'
+import { usePaymentToast } from '../use-payment-toast'
+
+// sonner is aliased to mocks/sonner.tsx in vitest.config.ts
+// toast.loading / toast.success / toast.error / toast.dismiss are vi.fn()
+
+function setMatchMedia(matchesMobile: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: matchesMobile ? query === '(max-width: 767px)' : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+}
+
+const BASE_PARAMS = {
+  idleSubState: 'ready' as const,
+  currency: 'USDC',
+  subtotal: '1000000',
+  decimals: 6,
+  networkId: 1,
+  error: null,
+}
+
+describe('usePaymentToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('desktop (>= 768px)', () => {
+    beforeEach(() => setMatchMedia(false))
+
+    it('calls sonnerToast.loading when an active step is present', () => {
+      const { rerender } = renderHook(
+        (props) => usePaymentToast(props),
+        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+      )
+
+      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+
+      expect(sonnerToast.loading).toHaveBeenCalled()
+    })
+
+    it('calls sonnerToast.success on success step', () => {
+      const { rerender } = renderHook(
+        (props) => usePaymentToast(props),
+        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+      )
+
+      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+      rerender({ ...BASE_PARAMS, step: 'success' as const })
+
+      expect(sonnerToast.success).toHaveBeenCalled()
+    })
+
+    it('calls sonnerToast.error on payment failure', () => {
+      const { rerender } = renderHook(
+        (props) => usePaymentToast(props),
+        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+      )
+
+      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+      rerender({
+        ...BASE_PARAMS,
+        step: 'idle' as const,
+        error: { message: 'User rejected' },
+      })
+
+      expect(sonnerToast.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('mobile (< 768px)', () => {
+    beforeEach(() => setMatchMedia(true))
+
+    it('does NOT call sonnerToast.loading during step transitions', () => {
+      const { rerender } = renderHook(
+        (props) => usePaymentToast(props),
+        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+      )
+
+      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+      rerender({ ...BASE_PARAMS, step: 'confirming' as const })
+
+      expect(sonnerToast.loading).not.toHaveBeenCalled()
+    })
+
+    it('still calls sonnerToast.success on success step', () => {
+      const { rerender } = renderHook(
+        (props) => usePaymentToast(props),
+        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+      )
+
+      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+      rerender({ ...BASE_PARAMS, step: 'success' as const })
+
+      expect(sonnerToast.success).toHaveBeenCalled()
+      expect(sonnerToast.loading).not.toHaveBeenCalled()
+    })
+
+    it('still calls sonnerToast.error on payment failure', () => {
+      const { rerender } = renderHook(
+        (props) => usePaymentToast(props),
+        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+      )
+
+      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+      rerender({
+        ...BASE_PARAMS,
+        step: 'idle' as const,
+        error: { message: 'User rejected' },
+      })
+
+      expect(sonnerToast.error).toHaveBeenCalled()
+      expect(sonnerToast.loading).not.toHaveBeenCalled()
+    })
+
+    it('calls sonnerToast.dismiss on user cancel', () => {
+      const { rerender } = renderHook(
+        (props) => usePaymentToast(props),
+        { initialProps: { ...BASE_PARAMS, step: 'idle' as const } },
+      )
+
+      rerender({ ...BASE_PARAMS, step: 'sending' as const })
+      rerender({ ...BASE_PARAMS, step: 'idle' as const, error: null })
+
+      expect(sonnerToast.dismiss).toHaveBeenCalled()
+    })
+  })
+
+  describe('connecting/switching steps on mobile', () => {
+    beforeEach(() => setMatchMedia(true))
+
+    it('does NOT call sonnerToast.loading for connecting step', () => {
+      const { rerender } = renderHook(
+        (props) => usePaymentToast(props),
+        {
+          initialProps: {
+            ...BASE_PARAMS,
+            idleSubState: 'disconnected' as const,
+            step: 'idle' as const,
+          },
+        },
+      )
+
+      rerender({
+        ...BASE_PARAMS,
+        idleSubState: 'disconnected' as const,
+        step: 'connecting' as const,
+      })
+
+      expect(sonnerToast.loading).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/features/payment/model/use-payment-toast.ts
+++ b/src/features/payment/model/use-payment-toast.ts
@@ -8,6 +8,7 @@
 import { useEffect, useRef, createElement } from 'react'
 import { toast as sonnerToast } from 'sonner'
 import { formatAmount } from '@/shared/lib/amount-utils'
+import { useIsMobile } from '@/shared/lib'
 import { getNetworkName } from '@/entities/network'
 import type { PaymentStep, IdleSubState } from './types'
 
@@ -166,6 +167,7 @@ export function usePaymentToast({
   error,
   devOverride,
 }: UsePaymentToastParams): void {
+  const isMobile = useIsMobile()
   const stepsRef = useRef<StepDef[] | null>(null)
   const startSubStateRef = useRef<IdleSubState>(idleSubState)
 
@@ -264,8 +266,8 @@ export function usePaymentToast({
       return
     }
 
-    // Active step — show/update progress toast
-    if (activeKey) {
+    // Active step — show/update progress toast (desktop only; mobile uses RainbowKit inline)
+    if (activeKey && !isMobile) {
       const done = countDone(steps, activeKey)
       const checklist = buildChecklist(steps, activeKey, false)
       const title = `Payment Progress (${done + 1}/${steps.length})`
@@ -276,7 +278,7 @@ export function usePaymentToast({
         duration: Infinity,
       })
     }
-  }, [step, idleSubState, currency, subtotal, decimals, networkId, error, devOverride])
+  }, [step, idleSubState, currency, subtotal, decimals, networkId, error, devOverride, isMobile])
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/shared/lib/hooks/index.ts
+++ b/src/shared/lib/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useHydrated } from './use-hydrated'
 export { useHashFragment } from './use-hash-fragment'
 export { useWagmiHydrating } from './use-wagmi-hydrating'
+export { useIsMobile } from './use-is-mobile'

--- a/src/shared/lib/hooks/use-is-mobile.ts
+++ b/src/shared/lib/hooks/use-is-mobile.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from 'react'
+
+const MOBILE_QUERY = '(max-width: 767px)'
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === 'undefined') return () => {}
+  const mql = window.matchMedia(MOBILE_QUERY)
+  mql.addEventListener('change', callback)
+  return () => mql.removeEventListener('change', callback)
+}
+
+function getSnapshot(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia(MOBILE_QUERY).matches
+}
+
+function getServerSnapshot(): boolean {
+  return false
+}
+
+/**
+ * Returns true when viewport width is < 768px (Tailwind `md` breakpoint).
+ * SSR-safe: server snapshot always returns false (no layout shift).
+ */
+export function useIsMobile(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,4 +1,4 @@
-export { useHydrated, useWagmiHydrating } from './hooks'
+export { useHydrated, useWagmiHydrating, useIsMobile } from './hooks'
 export { cn } from './utils'
 export { AUTO_SAVE_DEBOUNCE_MS, SEARCH_DEBOUNCE_MS } from './debounce'
 export { generateBlockieHash, getBlockieColor } from './blockie'


### PR DESCRIPTION
## Summary

- Suppress `sonnerToast.loading` (sticky payment-progress toast) on mobile viewports (`< 768px`)
- Keep error / success / finalization toasts on all viewports
- Adds SSR-safe `useIsMobile()` hook in `shared/lib/hooks/`

## Why

On mobile, the RainbowKit connect modal already renders the payment-progress steps inline. The sticky toast was a redundant duplicate that obscured the wallet picker. Desktop is unaffected (corner-pinned toast doesn't compete with the modal).

Closes #215.

## Test plan

- [x] `pnpm type-check:build` — clean
- [x] `pnpm test src/features/payment/model/__tests__/use-payment-toast.test.ts` — 8/8 pass
- [x] Mobile viewport: no progress toast during connect → switch → send → confirm
- [x] Mobile viewport: error toast still fires on rejection
- [x] Mobile viewport: success toast still fires on send
- [x] Mobile viewport: finalization toast still fires on deep-confirm
- [x] Desktop viewport: behavior unchanged

## Notes

- New `useIsMobile()` uses `useSyncExternalStore` for SSR safety; defaults to non-mobile during hydration to avoid flash on desktop.
- 12 pre-existing lint errors (`react-hooks/set-state-in-effect` not found) are **not** introduced by this PR — they exist on `develop` due to eslint-plugin-react-hooks v7 config drift. Will file a separate issue.