### PR TITLE
docs(readme): add @void-layer codec standard one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Privacy-first crypto invoicing. All data lives in the URL. [Try it →](https://voidpay.xyz)
 
+> Built on [@void-layer](https://github.com/void-layer) — the open invoice codec standard.
+
 ---
 
 ## How It Works


### PR DESCRIPTION
## Summary

- Adds `> Built on [@void-layer](https://github.com/void-layer) — the open invoice codec standard.` one-liner under README hero
- Closes AI#109 (spec-066 Phase 1 §6.2)

## Context

Spec 066 (`void-layer-repositioning`) §2.2 mandates the @void-layer brand surface under the main hero. Phase 1 acceptance criteria checkbox was optimistic — verified missing today during /team.spark-cmo session-start audit.

Doctrine: Variant A (standards-adoption + adapter bridge), ratified 2026-05-19.

## Test plan

- [x] Renders cleanly under tagline, before `---` separator
- [x] Voice Sweep-2: "open invoice codec standard" matches voice-constraint #7 allowed phrasing
- [x] No competitor framing; architectural ("Built on", not promissory)
- [ ] Live preview on GitHub repo page after merge