### PR TITLE
fix(copy): drop "no tracking" overclaim, surface Base (AI#86)

### DIFF
--- a/src/app/(app)/pay/page.tsx
+++ b/src/app/(app)/pay/page.tsx
@@ -47,7 +47,7 @@ export async function generateMetadata({
       preview.to ? `to ${preview.to}` : '',
     ].filter(Boolean).join(' ')
     const title = `Pay ${preview.amount} ${preview.currency} — Invoice ${preview.id} | VoidPay`
-    const description = `Crypto invoice for ${preview.amount} ${preview.currency} on ${networkDisplayName}${fromTo ? ` ${fromTo}` : ''}. Pay instantly with your wallet — no signup, no tracking. Powered by VoidPay.`
+    const description = `Crypto invoice for ${preview.amount} ${preview.currency} on ${networkDisplayName}${fromTo ? ` ${fromTo}` : ''}. Pay instantly with your wallet — no signup, no KYC. Powered by VoidPay.`
 
     const images = dynamicOgImages(og)
 

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -90,7 +90,7 @@ const howToSchema = {
 export const metadata: Metadata = {
   title: 'Free Crypto Invoice Generator | No KYC | VoidPay',
   description:
-    'Create crypto invoices in 30 seconds. No accounts, no KYC, no servers. Your data lives in the URL, not our database. Works on ETH, ARB, OP.',
+    'Create crypto invoices in 30 seconds. No accounts, no KYC, no servers. Your data lives in the URL, not our database. Works on Ethereum, Base, Arbitrum, Optimism, Polygon.',
   keywords: [
     'crypto invoice',
     'crypto invoicing',
@@ -113,7 +113,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'VoidPay - Create Crypto Invoices Without Signup',
     description:
-      'Privacy-first invoicing for Web3. No accounts, no servers. Your invoice = your URL. Works on Ethereum, Arbitrum, Optimism.',
+      'Privacy-first invoicing for Web3. No accounts, no servers. Your invoice = your URL. Works on Ethereum, Base, Arbitrum, Optimism.',
     url: APP_URLS.base,
     siteName: 'VoidPay',
     type: 'website',

--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -17,7 +17,7 @@ import { WaitlistForm } from './_components/waitlist-form'
 export const metadata: Metadata = {
   title: 'Coming Soon | VoidPay',
   description:
-    'Privacy-first crypto invoicing is coming. No signup, no tracking, no backend. Join the waitlist for early access.',
+    'Privacy-first crypto invoicing is coming. No signup, no KYC, no backend. Join the waitlist for early access.',
   robots: { index: true, follow: true },
   openGraph: {
     title: 'VoidPay — Coming Soon',
@@ -73,7 +73,7 @@ export default function ComingSoonPage() {
             className="mx-auto max-w-2xl px-4 leading-relaxed font-light text-zinc-400/90"
           >
             Privacy-first crypto invoicing —{' '}
-            <span className="font-medium text-zinc-100">no signup, no tracking, no backend.</span>
+            <span className="font-medium text-zinc-100">no signup, no KYC, no backend.</span>
           </Text>
         </div>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,14 +31,14 @@ export const metadata: Metadata = {
         : 'https://voidpay.xyz'),
   ),
   title: 'VoidPay — Stateless Crypto Invoicing. No Backend, Just Links.',
-  description: 'Create privacy-first crypto invoices in seconds. All data lives in the URL — no backend, no signup, no tracking. Works even if we shut down.',
+  description: 'Create privacy-first crypto invoices in seconds. All data lives in the URL — no backend, no signup, no KYC. Works even if we shut down.',
   icons: {
     icon: '/favicon.svg',
     apple: '/favicon.svg',
   },
   openGraph: {
     title: 'VoidPay — Crypto Invoices Without the Backend. Just Share a Link.',
-    description: 'Create privacy-first crypto invoices in seconds. All data lives in the URL — no backend, no signup, no tracking. Pay with any wallet on Ethereum, Base, Arbitrum, Optimism, or Polygon.',
+    description: 'Create privacy-first crypto invoices in seconds. All data lives in the URL — no backend, no signup, no KYC. Pay with any wallet on Ethereum, Base, Arbitrum, Optimism, or Polygon.',
     url: 'https://voidpay.xyz',
     siteName: 'VoidPay',
     locale: 'en_US',
@@ -48,7 +48,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'VoidPay — Crypto Invoices Without the Backend. Just Share a Link.',
-    description: 'Create privacy-first crypto invoices in seconds. All data lives in the URL — no backend, no signup, no tracking. Pay with any wallet on Ethereum, Base, Arbitrum, Optimism, or Polygon.',
+    description: 'Create privacy-first crypto invoices in seconds. All data lives in the URL — no backend, no signup, no KYC. Pay with any wallet on Ethereum, Base, Arbitrum, Optimism, or Polygon.',
     images: [{ url: '/og-image.png', width: 1200, height: 630, alt: 'VoidPay — Stateless Crypto Invoicing' }],
   },
   appleWebApp: {

--- a/src/widgets/landing/constants/features.tsx
+++ b/src/widgets/landing/constants/features.tsx
@@ -41,7 +41,7 @@ export const FEATURE_CARDS: FeatureCard[] = [
     id: 'immutable',
     title: 'Immutable',
     description:
-      'Once an invoice link is generated, it cannot be changed. The data is cryptographically secure within the link itself.',
+      "Once you share an invoice link, the details can't be altered. The data is baked into the URL — tamper with it and it simply won't open.",
     icon: ShieldIcon,
     iconColor: 'text-emerald-500',
   },

--- a/src/widgets/landing/hero-section/HeroSection.tsx
+++ b/src/widgets/landing/hero-section/HeroSection.tsx
@@ -26,14 +26,14 @@ export function HeroSection() {
       <div className="pointer-events-none absolute top-1/2 left-1/2 -z-10 h-[min(800px,150vw)] w-[min(800px,150vw)] -translate-x-1/2 -translate-y-1/2 rounded-full bg-violet-600/10 blur-[120px]" />
 
       <div className="hero-animate-container relative z-20 mx-auto max-w-5xl space-y-10">
-        {/* Free • Open Source • Zero Tracking badge */}
+        {/* Free • Open Source • Zero Backend badge */}
         <div className="hero-animate-badge mx-auto inline-flex cursor-default items-center gap-2 rounded-full border border-zinc-800 bg-zinc-900/50 px-3 py-1 shadow-lg backdrop-blur transition-colors hover:border-violet-500/50">
           <span className="relative flex h-2 w-2">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-violet-400 opacity-75" />
             <span className="relative inline-flex h-2 w-2 rounded-full bg-violet-500" />
           </span>
           <span className="text-xs font-medium tracking-wide text-zinc-300">
-            Free • Open Source • Zero Tracking
+            Free • Open Source • Zero Backend
           </span>
         </div>
 
@@ -52,7 +52,7 @@ export function HeroSection() {
           className="mx-auto max-w-2xl px-4 leading-relaxed font-light text-zinc-400/90"
         >
           Stateless web3 invoicing —{' '}
-          <span className="font-medium text-zinc-100">no servers, no accounts, no tracking.</span>
+          <span className="font-medium text-zinc-100">no servers, no accounts, no KYC.</span>
         </Text>
 
         {/* CTA */}

--- a/src/widgets/landing/hero-section/__tests__/HeroSection.test.tsx
+++ b/src/widgets/landing/hero-section/__tests__/HeroSection.test.tsx
@@ -66,7 +66,7 @@ describe('HeroSection', () => {
     it('should display the Open Source badge', () => {
       render(<HeroSection />)
 
-      expect(screen.getByText(/Open Source.*Zero Tracking/)).toBeInTheDocument()
+      expect(screen.getByText(/Open Source.*Zero Backend/)).toBeInTheDocument()
     })
   })
 
@@ -91,7 +91,7 @@ describe('HeroSection', () => {
 
       // Main value proposition - SEO: stateless web3 invoicing
       expect(screen.getByText(/Stateless web3 invoicing/i)).toBeInTheDocument()
-      expect(screen.getByText(/no servers, no accounts, no tracking/i)).toBeInTheDocument()
+      expect(screen.getByText(/no servers, no accounts, no KYC/i)).toBeInTheDocument()
     })
   })
 

--- a/src/widgets/landing/social-proof/SocialProofStrip.tsx
+++ b/src/widgets/landing/social-proof/SocialProofStrip.tsx
@@ -40,7 +40,7 @@ const TRUST_BADGES: TrustBadgeData[] = [
   {
     icon: GlobeIcon,
     label: 'Multi-Chain',
-    description: 'ETH • Arbitrum • Optimism • Polygon',
+    description: 'ETH • Base • Arbitrum • Optimism • Polygon',
   },
 ]
 

--- a/src/widgets/landing/social-proof/__tests__/SocialProofStrip.test.tsx
+++ b/src/widgets/landing/social-proof/__tests__/SocialProofStrip.test.tsx
@@ -24,7 +24,7 @@ describe('SocialProofStrip', () => {
       expect(screen.getByText('No servers, no databases')).toBeInTheDocument()
       expect(screen.getByText('Verify the code yourself')).toBeInTheDocument()
       expect(screen.getByText('Deploy locally if we disappear')).toBeInTheDocument()
-      expect(screen.getByText('ETH • Arbitrum • Optimism • Polygon')).toBeInTheDocument()
+      expect(screen.getByText('ETH • Base • Arbitrum • Optimism • Polygon')).toBeInTheDocument()
     })
   })
 

--- a/src/widgets/share-modal/ui/LinkTab.tsx
+++ b/src/widgets/share-modal/ui/LinkTab.tsx
@@ -185,7 +185,7 @@ export function LinkTab({
       <div className="flex items-start gap-2 px-1">
         <LockIcon size={12} className="mt-0.5 shrink-0 text-zinc-600" />
         <p className="text-xs leading-relaxed text-zinc-500">
-          <strong className="text-zinc-400">Privacy by design.</strong> Invoice data is encoded in the link. No servers. No tracking.
+          <strong className="text-zinc-400">Privacy by design.</strong> Invoice data is encoded in the link. No servers. We can&apos;t see it.
         </p>
       </div>
     </div>

--- a/src/widgets/share-modal/ui/__tests__/LinkTab.test.tsx
+++ b/src/widgets/share-modal/ui/__tests__/LinkTab.test.tsx
@@ -90,7 +90,7 @@ describe('LinkTab', () => {
     renderWithUser()
     expect(screen.getByText(/privacy by design/i)).toBeInTheDocument()
     expect(screen.getByText(/no servers/i)).toBeInTheDocument()
-    expect(screen.getByText(/no tracking/i)).toBeInTheDocument()
+    expect(screen.getByText(/can't see it/i)).toBeInTheDocument()
   })
 
   it('shows Copied state with emerald styling when copied=true', () => {


### PR DESCRIPTION
## Why
Landing marketing analysis (AI#86, Spark) surfaced two **voice-invariant violations** and a factual omission. All copy/data — no logic changes.

## Voice / honesty ("we can't > we won't" — voice-constraints #1, #4)
The app fires `track()` events (Umami cookie-free analytics) and the FAQ admits as much — so **"Zero Tracking" / "no tracking" was an overclaim** the page contradicted itself on.

- **Hero**: badge `Zero Tracking → Zero Backend`; subhead `no tracking → no KYC`
- **App-wide** (same false claim): root `layout.tsx` metadata, `coming-soon`, `/pay` OG description
- **Share modal `LinkTab`**: `No tracking → We can't see it` — the invoice hash never leaves the browser, so this scoped claim is *architecturally true* (stronger, not weaker)
- **"Immutable" feature card**: `cryptographically secure → tamper-evident` framing (it's Brotli+Base64url encoding, not encryption — matches the FAQ)

## Correctness
- **Base** was missing from `SocialProofStrip` Multi-Chain list → added
- **Base** (+ full network list) added to landing `meta` + OG descriptions

## Validation
- type-check 0 errors · lint 0 errors (12 pre-existing warnings, untouched)
- Affected tests updated + green (landing 28/28, share-modal/pay/coming-soon 113/113)

Remaining landing findings (F3 trust-proof, F4 pacing, F5 unrendered cards, F6 tagline, F7 comparison order, F11 schema) filed as separate issues under AI#86.