### PR TITLE
fix(privacy): trust-day T1+T2 — reframe blocklist copy + exclude og-params from Umami

### DIFF
--- a/src/app/privacy/content.ts
+++ b/src/app/privacy/content.ts
@@ -144,25 +144,27 @@ export const privacyContent = {
     },
     {
       id: 'abuse-prevention',
-      title: 'Abuse Prevention (Privacy-Preserving)',
+      title: 'Abuse Prevention (Privacy-Preserving Design)',
       content:
-        "To prevent phishing and scam invoices, we maintain a public blocklist of known malicious URLs. Here's how we protect privacy while doing this:",
+        'Should we ever deploy an abuse-prevention blocklist to protect users from phishing and scam invoices, it would be implemented in a privacy-preserving way. No such blocklist is currently live. The design guarantees for any future mechanism would be:',
       items: [
         {
-          label: 'SHA-256 hashes',
-          description: 'The blocklist contains only hashes of malicious URL fragments',
+          label: 'SHA-256 hashes only',
+          description:
+            'Any blocklist would contain only hashes of malicious URL fragments — never raw invoice data',
         },
         {
-          label: 'Irreversible',
-          description: 'Hashes are irreversible — you cannot recover invoice data from them',
+          label: 'Irreversible by design',
+          description: 'Hashes would be irreversible — invoice data could not be recovered from them',
         },
         {
           label: 'Client-side checking',
-          description: 'Your invoice URL is never sent to our servers for validation',
+          description: 'Your invoice URL would never be sent to our servers for validation',
         },
         {
           label: 'Public on GitHub',
-          description: 'The blocklist is public for transparency and community review',
+          description:
+            'Any such blocklist would be published publicly for transparency and community review',
         },
       ],
     },

--- a/src/features/analytics/ui/UmamiScript.tsx
+++ b/src/features/analytics/ui/UmamiScript.tsx
@@ -14,6 +14,7 @@ import { UMAMI_CONFIG } from '../config/umami'
  * - Not rendered in development (no network request)
  * - data-domains restricts tracking to production domain only (blocks preview deploys)
  * - data-exclude-hash strips URL hash fragment (PRIVACY-CRITICAL: hash contains full invoice data)
+ * - data-exclude-search strips URL query string (PRIVACY-CRITICAL: og params carry invoice amount + names)
  *
  * @see https://umami.is/docs/tracker-configuration
  */
@@ -26,6 +27,7 @@ export function UmamiScript() {
       data-website-id={UMAMI_CONFIG.websiteId}
       data-domains={VOIDPAY_DOMAIN}
       data-exclude-hash="true"
+      data-exclude-search="true"
       strategy="lazyOnload"
     />
   )

--- a/src/features/analytics/ui/__tests__/UmamiScript.test.tsx
+++ b/src/features/analytics/ui/__tests__/UmamiScript.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@/shared/lib/test-utils'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { UmamiScript } from '../UmamiScript'
+
+// Expose Script props as data attributes — next/script renders nothing testable in happy-dom
+vi.mock('next/script', () => ({
+  default: (props: Record<string, string>) => (
+    <script
+      data-testid="umami-script"
+      data-exclude-hash={props['data-exclude-hash']}
+      data-exclude-search={props['data-exclude-search']}
+    />
+  ),
+}))
+
+describe('UmamiScript', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('emits data-exclude-hash and data-exclude-search in production', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+
+    render(<UmamiScript />)
+
+    const script = screen.getByTestId('umami-script')
+    expect(script).toHaveAttribute('data-exclude-hash', 'true')
+    expect(script).toHaveAttribute('data-exclude-search', 'true')
+  })
+
+  it('does not render outside production', () => {
+    render(<UmamiScript />)
+    expect(screen.queryByTestId('umami-script')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Trust-day fixes from the 2026-06-10 viability audit (§9). Two surgical privacy-integrity fixes. Both findings verified by direct code inspection before acting.

## T1 — Blocklist copy → conditional (no mechanism built)
`privacy/content.ts` asserted present-tense "we **maintain** a public blocklist" — but no blocklist code or data file exists anywhere in `src`. For a privacy-first brand that's a live misrepresentation. Reframed the `abuse-prevention` section to conditional / reserve-the-right (matching `terms.ts`, which already said "reserve the right to add"). Privacy-design intent preserved as a *future* guarantee; **no moderation infra built** (respects the audit's own META-freeze recommendation).

- Opening → "Should we ever deploy… No such blocklist is currently live."
- Title → "Abuse Prevention (Privacy-Preserving **Design**)"
- All 4 items → conditional tense
- Cross-checked: `open-source` section ("every claim verifiable in code") stays valid — no residual live-mechanism claim remains in privacy **or** terms.

## T2 — Exclude URL query from Umami (og-param PII leak)
`UmamiScript.tsx` stripped the hash fragment but **not** the query string, so `?og=INV_amount_name` (invoice amounts + names) reached Umami — verified 93 events, last 2026-06-06 — contradicting "collects no personal or financial data" (Constitution Pillar II).

- Added `data-exclude-search="true"` beside `data-exclude-hash="true"`
- New test asserts both exclude attrs + non-production renders null
- **Trade-off (accepted):** `data-exclude-search` is global — it also strips future UTM/campaign params. Privacy wins by default; attribution routes via `?ref=` / distinct landing paths.

## Validation
- `pnpm type-check:build` → exit 0
- `pnpm lint` → 0 errors (12 pre-existing warnings in features/payment)
- New `UmamiScript.test.tsx` → 2/2 green

## Not in this PR
- T3 (purge 37 pre-launch hash rows) — drafted as `trust-t3-purge.sql`, needs Supabase write
- T4 (publish wire-format standard) — deferred

Decision record: `agent-memory/advisors/decisions/2026-06-10-kai-cto-trust-t1t2-dispositions.md`