### PR TITLE
fix(ci): dedup remotion@4.0.477 in pnpm-lock — unblock develop

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5575,12 +5575,6 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  remotion@4.0.477:
-    resolution: {integrity: sha512-mxQ8MHmx9YUpxyTSm8hLZW/LGvOzk9b19i02DT9MKKFv+H6ZXkd/1Cn+a908fZWCqM4RRCIy3poXB8KsHiPdow==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -13061,11 +13055,6 @@ snapshots:
       set-function-name: 2.0.2
 
   remotion@4.0.474(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
-  remotion@4.0.477(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)


### PR DESCRIPTION
## What
Removes two byte-identical duplicate mapping keys from `pnpm-lock.yaml` that broke `pnpm install --frozen-lockfile` at YAML parse on `develop`:
- `packages:` → `remotion@4.0.477` (duplicated)
- `snapshots:` → `remotion@4.0.477(react-dom@19.2.7(react@19.2.7))(react@19.2.7)` (duplicated)

## Why
`develop` has been red since ~Jul 1 — every PR (dependabot + feature) fails at install parse, before any code runs. Introduced as a dependabot merge-artifact from concurrent remotion 4.0.477 bumps (#326 + #328). Same class as #319; long-term prevention tracked in #207.

## Verification
- Section-aware dup scan: 0 duplicates in both `packages:` and `snapshots:`.
- `pnpm install --frozen-lockfile` passes locally (was failing at parse).
- Diff is a pure deletion of the two duplicate blocks — no version changes.

https://claude.ai/code/session_01HWZgdxCJUGrmfqz8NaUHHW